### PR TITLE
fix: heading border system overhaul with multi-border, spacing, and refactoring

### DIFF
--- a/csharp-version/src/MarkdownToDocx.CLI/MarkdownToDocx.CLI.csproj
+++ b/csharp-version/src/MarkdownToDocx.CLI/MarkdownToDocx.CLI.csproj
@@ -14,6 +14,7 @@
     <PackageProjectUrl>https://github.com/forest6511/md2docx</PackageProjectUrl>
     <RepositoryUrl>https://github.com/forest6511/md2docx</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp-version/src/MarkdownToDocx.Core/Models/HeadingStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/HeadingStyle.cs
@@ -36,6 +36,26 @@ public sealed record HeadingStyle
     public uint BorderSize { get; init; } = 24;
 
     /// <summary>
+    /// Space between border and content in points
+    /// </summary>
+    public uint BorderSpace { get; init; } = 0;
+
+    /// <summary>
+    /// Border position ("bottom", "left", "right", "top")
+    /// </summary>
+    public string BorderPosition { get; init; } = "bottom";
+
+    /// <summary>
+    /// Background color in hexadecimal format (optional)
+    /// </summary>
+    public string? BackgroundColor { get; init; }
+
+    /// <summary>
+    /// Line spacing in twips (exact mode). Null uses default line spacing.
+    /// </summary>
+    public string? LineSpacing { get; init; }
+
+    /// <summary>
     /// Space before heading in twips
     /// </summary>
     public string SpaceBefore { get; init; } = "400";

--- a/csharp-version/src/MarkdownToDocx.Core/Models/QuoteStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/QuoteStyle.cs
@@ -41,6 +41,11 @@ public sealed record QuoteStyle
     public uint BorderSize { get; init; } = 24;
 
     /// <summary>
+    /// Space between border and content in points
+    /// </summary>
+    public uint BorderSpace { get; init; } = 0;
+
+    /// <summary>
     /// Background color in hexadecimal format (optional)
     /// </summary>
     public string? BackgroundColor { get; init; }

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -92,6 +92,26 @@ public sealed class HeadingStyleConfig
     public uint BorderSize { get; init; } = 12;
 
     /// <summary>
+    /// Space between border and content in points (default: 0)
+    /// </summary>
+    public uint BorderSpace { get; init; } = 0;
+
+    /// <summary>
+    /// Border position ("bottom", "left", "right", "top")
+    /// </summary>
+    public string BorderPosition { get; init; } = "bottom";
+
+    /// <summary>
+    /// Background color in hex format, or null for no background
+    /// </summary>
+    public string? BackgroundColor { get; init; }
+
+    /// <summary>
+    /// Line spacing in twips (exact mode). Null uses default line spacing.
+    /// </summary>
+    public string? LineSpacing { get; init; }
+
+    /// <summary>
     /// Spacing before heading in twips (1/20 of a point)
     /// </summary>
     public string SpaceBefore { get; init; } = "240";
@@ -254,6 +274,11 @@ public sealed class QuoteStyleConfig
     /// Border thickness in eighths of a point (default: 12 = 1.5pt)
     /// </summary>
     public uint BorderSize { get; init; } = 12;
+
+    /// <summary>
+    /// Space between border and content in points (default: 0)
+    /// </summary>
+    public uint BorderSpace { get; init; } = 0;
 
     /// <summary>
     /// Border position ("left", "right", "top", "bottom")

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -39,6 +39,10 @@ public sealed class StyleApplicator : IStyleApplicator
             ShowBorder = headingConfig.ShowBorder,
             BorderColor = headingConfig.BorderColor,
             BorderSize = headingConfig.BorderSize,
+            BorderSpace = headingConfig.BorderSpace,
+            BorderPosition = headingConfig.BorderPosition,
+            BackgroundColor = headingConfig.BackgroundColor,
+            LineSpacing = headingConfig.LineSpacing,
             SpaceBefore = headingConfig.SpaceBefore,
             SpaceAfter = headingConfig.SpaceAfter
         };
@@ -107,6 +111,7 @@ public sealed class StyleApplicator : IStyleApplicator
             ShowBorder = config.Quote.ShowBorder,
             BorderColor = config.Quote.BorderColor,
             BorderSize = config.Quote.BorderSize,
+            BorderSpace = config.Quote.BorderSpace,
             BorderPosition = config.Quote.BorderPosition,
             BackgroundColor = config.Quote.BackgroundColor,
             LeftIndent = config.Quote.LeftIndent,

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -520,6 +520,158 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         textContent.Should().Contain("Important note");
     }
 
+    [Fact]
+    public void AddHeading_WithShowBorderOnH2_ShouldRenderBorder()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new HeadingStyle
+        {
+            FontSize = 26,
+            Color = "333333",
+            Bold = true,
+            ShowBorder = true,
+            BorderColor = "e8a735",
+            BorderSize = 16,
+            BorderPosition = "bottom",
+            SpaceBefore = "200",
+            SpaceAfter = "200"
+        };
+
+        // Act
+        builder.AddHeading(2, "H2 with border", style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        var borders = paragraph.ParagraphProperties?.ParagraphBorders;
+        borders.Should().NotBeNull();
+        borders!.Elements<BottomBorder>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void AddHeading_WithBorderPositionLeft_ShouldRenderLeftBorder()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new HeadingStyle
+        {
+            FontSize = 26,
+            Color = "333333",
+            Bold = true,
+            ShowBorder = true,
+            BorderColor = "4a90e2",
+            BorderSize = 24,
+            BorderPosition = "left",
+            SpaceBefore = "200",
+            SpaceAfter = "200"
+        };
+
+        // Act
+        builder.AddHeading(3, "H3 with left border", style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        var borders = paragraph.ParagraphProperties?.ParagraphBorders;
+        borders.Should().NotBeNull();
+        borders!.Elements<LeftBorder>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void AddHeading_WithBackgroundColor_ShouldRenderShading()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new HeadingStyle
+        {
+            FontSize = 22,
+            Color = "ffffff",
+            Bold = true,
+            ShowBorder = false,
+            BackgroundColor = "f0b64d",
+            SpaceBefore = "200",
+            SpaceAfter = "200"
+        };
+
+        // Act
+        builder.AddHeading(3, "H3 with background", style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        var shading = paragraph.ParagraphProperties?.Shading;
+        shading.Should().NotBeNull();
+        shading!.Fill!.Value.Should().Be("f0b64d");
+    }
+
+    [Fact]
+    public void AddHeading_WithNullBackgroundColor_ShouldNotRenderShading()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new HeadingStyle
+        {
+            FontSize = 32,
+            Color = "333333",
+            Bold = true,
+            ShowBorder = false,
+            BackgroundColor = null,
+            SpaceBefore = "240",
+            SpaceAfter = "120"
+        };
+
+        // Act
+        builder.AddHeading(1, "H1 without background", style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        var shading = paragraph.ParagraphProperties?.Shading;
+        shading.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddHeading_WithDefaultBorderPosition_ShouldRenderBottomBorder()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new HeadingStyle
+        {
+            FontSize = 32,
+            Color = "333333",
+            Bold = true,
+            ShowBorder = true,
+            BorderColor = "e8a735",
+            BorderSize = 32,
+            // BorderPosition not set - should default to "bottom"
+            SpaceBefore = "240",
+            SpaceAfter = "240"
+        };
+
+        // Act
+        builder.AddHeading(1, "H1 default border", style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        var borders = paragraph.ParagraphProperties?.ParagraphBorders;
+        borders.Should().NotBeNull();
+        borders!.Elements<BottomBorder>().Should().NotBeEmpty();
+        var bottomBorder = borders.Elements<BottomBorder>().First();
+        bottomBorder.Color!.Value.Should().Be("e8a735");
+    }
+
     public void Dispose()
     {
         _stream?.Dispose();

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
@@ -97,6 +97,46 @@ public class StyleApplicatorTests
     }
 
     [Fact]
+    public void ApplyHeadingStyle_ShouldMapBorderPositionAndBackgroundColor()
+    {
+        // Arrange
+        var config = new StyleConfiguration
+        {
+            H2 = new HeadingStyleConfig
+            {
+                Size = 13,
+                Bold = true,
+                Color = "333333",
+                ShowBorder = true,
+                BorderColor = "e8a735",
+                BorderSize = 16,
+                BorderPosition = "left",
+                BackgroundColor = "faf5eb"
+            }
+        };
+
+        // Act
+        var style = _applicator.ApplyHeadingStyle(2, config);
+
+        // Assert
+        style.BorderPosition.Should().Be("left");
+        style.BackgroundColor.Should().Be("faf5eb");
+        style.ShowBorder.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ApplyHeadingStyle_WithDefaultBorderPosition_ShouldBeBottom()
+    {
+        // Arrange - H1 in test config has no explicit BorderPosition
+        // Act
+        var style = _applicator.ApplyHeadingStyle(1, _testConfig);
+
+        // Assert
+        style.BorderPosition.Should().Be("bottom");
+        style.BackgroundColor.Should().BeNull();
+    }
+
+    [Fact]
     public void ApplyParagraphStyle_ShouldReturnCorrectStyle()
     {
         // Act


### PR DESCRIPTION
## Summary

- **Fix Issues #1, #2, #3**: Resolve assembly loading (CopyLocalLockFileAssemblies), heading BackgroundColor support, and LeftBorder→BottomBorder default fix
- **New YAML-configurable properties**: BorderPosition (comma-separated, e.g. "bottom,left"), BorderSpace, LineSpacing (Exact mode) for headings; BorderSpace for quotes
- **Refactor OpenXmlDocumentBuilder**: Extract 4 shared helpers (CreateBaseParagraphProperties, CreateBordersFromPositions, CreateBaseRunProperties, CreateBackgroundShading), reducing ~24% code duplication (551→420 lines)
- **Add 7 new unit tests** covering border positions, background color, and style mapping

## Test plan

- [x] All 89 existing tests pass
- [x] 7 new tests added for border/shading/style scenarios
- [x] Manual DOCX verification with KDP A5 preset (H1/H2 L-shaped borders, blockquote background)
- [ ] Verify YAML backward compatibility (default values match previous behavior)

Closes #1, Closes #2, Closes #3