### PR TITLE
feat: set outline level on headings for TOC and navigation

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -185,7 +185,7 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
         }
 
         var paragraph = _body.AppendChild(new Paragraph());
-        var paragraphProps = CreateHeadingParagraphProperties(style);
+        var paragraphProps = CreateHeadingParagraphProperties(level, style);
         paragraph.AppendChild(paragraphProps);
 
         var run = paragraph.AppendChild(new Run());
@@ -196,9 +196,12 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     /// <summary>
     /// Creates paragraph properties for heading elements
     /// </summary>
-    private ParagraphProperties CreateHeadingParagraphProperties(HeadingStyle style)
+    private ParagraphProperties CreateHeadingParagraphProperties(int level, HeadingStyle style)
     {
         var props = CreateBaseParagraphProperties();
+
+        // Outline level for TOC and navigation support (0-based: H1=0, H2=1, ...)
+        props.AppendChild(new OutlineLevel { Val = level - 1 });
 
         // Page break before
         if (style.PageBreakBefore)


### PR DESCRIPTION
## Summary
- Add `OutlineLevel` to heading paragraph properties (0-based: H1=0 through H6=5)
- Enables Word's built-in TOC, navigation pane, PDF bookmarks, and screen reader support
- Prerequisite for #6 (TOC generation)

## Test plan
- [x] Theory test: all 6 heading levels map to correct OutlineLevel (0-5)
- [x] Multiple headings in same document maintain independent outline levels
- [x] All 104 tests passing

Closes #8