### PR TITLE
feat: add configurable table of contents generation

### DIFF
--- a/config/presets/minimal.yaml
+++ b/config/presets/minimal.yaml
@@ -25,6 +25,12 @@ Fonts:
   EastAsia: "Noto Serif CJK JP"
   DefaultSize: 11
 
+TableOfContents:
+  Enabled: false
+  Depth: 3
+  Title: "Contents"
+  PageBreakAfter: true
+
 Styles:
   H1:
     Size: 24

--- a/csharp-version/src/MarkdownToDocx.Core/Interfaces/IDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Interfaces/IDocumentBuilder.cs
@@ -46,6 +46,13 @@ public interface IDocumentBuilder : IDisposable
     void AddQuote(string text, QuoteStyle style);
 
     /// <summary>
+    /// Adds a table of contents to the document.
+    /// Must be called before any content (headings, paragraphs, etc.) is added.
+    /// </summary>
+    /// <param name="style">Table of contents style configuration</param>
+    void AddTableOfContents(TableOfContentsStyle style);
+
+    /// <summary>
     /// Adds a thematic break (horizontal rule) to the document
     /// </summary>
     void AddThematicBreak();

--- a/csharp-version/src/MarkdownToDocx.Core/Models/TableOfContentsStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/TableOfContentsStyle.cs
@@ -1,0 +1,27 @@
+namespace MarkdownToDocx.Core.Models;
+
+/// <summary>
+/// Represents styling configuration for table of contents generation
+/// </summary>
+public sealed record TableOfContentsStyle
+{
+    /// <summary>
+    /// Whether TOC generation is enabled
+    /// </summary>
+    public bool Enabled { get; init; } = false;
+
+    /// <summary>
+    /// Heading depth to include (1-6, e.g., 3 = H1-H3)
+    /// </summary>
+    public int Depth { get; init; } = 3;
+
+    /// <summary>
+    /// Optional title displayed above the TOC (null or empty = no title)
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Whether to insert a page break after the TOC
+    /// </summary>
+    public bool PageBreakAfter { get; init; } = false;
+}

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -174,6 +174,65 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     }
 
     /// <inheritdoc/>
+    public void AddTableOfContents(TableOfContentsStyle style)
+    {
+        ArgumentNullException.ThrowIfNull(style);
+
+        if (!style.Enabled)
+        {
+            return;
+        }
+
+        // Optional title paragraph
+        if (!string.IsNullOrEmpty(style.Title))
+        {
+            var titleParagraph = _body.AppendChild(new Paragraph());
+            var titleProps = CreateBaseParagraphProperties();
+            titleProps.AppendChild(new SpacingBetweenLines { Before = "240", After = "120" });
+            titleParagraph.AppendChild(titleProps);
+
+            var titleRun = titleParagraph.AppendChild(new Run());
+            titleRun.AppendChild(CreateBaseRunProperties(32, "000000", bold: true));
+            titleRun.AppendChild(new Text(style.Title) { Space = SpaceProcessingModeValues.Preserve });
+        }
+
+        // TOC field code paragraph
+        var tocParagraph = _body.AppendChild(new Paragraph());
+        var tocProps = CreateBaseParagraphProperties();
+        tocParagraph.AppendChild(tocProps);
+
+        // Begin field
+        var beginRun = tocParagraph.AppendChild(new Run());
+        beginRun.AppendChild(new FieldChar { FieldCharType = FieldCharValues.Begin });
+
+        // Instruction text
+        var instrRun = tocParagraph.AppendChild(new Run());
+        instrRun.AppendChild(new FieldCode($" TOC \\o \"1-{style.Depth}\" \\h \\z \\u ")
+        {
+            Space = SpaceProcessingModeValues.Preserve
+        });
+
+        // Separate field
+        var separateRun = tocParagraph.AppendChild(new Run());
+        separateRun.AppendChild(new FieldChar { FieldCharType = FieldCharValues.Separate });
+
+        // End field
+        var endRun = tocParagraph.AppendChild(new Run());
+        endRun.AppendChild(new FieldChar { FieldCharType = FieldCharValues.End });
+
+        // Optional page break after TOC
+        if (style.PageBreakAfter)
+        {
+            var breakParagraph = _body.AppendChild(new Paragraph());
+            var breakProps = CreateBaseParagraphProperties();
+            breakParagraph.AppendChild(breakProps);
+
+            var breakRun = breakParagraph.AppendChild(new Run());
+            breakRun.AppendChild(new Break { Type = BreakValues.Page });
+        }
+    }
+
+    /// <inheritdoc/>
     public void AddHeading(int level, string text, HeadingStyle style)
     {
         ArgumentNullException.ThrowIfNull(text);

--- a/csharp-version/src/MarkdownToDocx.Styling/Interfaces/IStyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Interfaces/IStyleApplicator.cs
@@ -43,4 +43,11 @@ public interface IStyleApplicator
     /// <param name="config">Style configuration</param>
     /// <returns>Quote style</returns>
     QuoteStyle ApplyQuoteStyle(StyleConfiguration config);
+
+    /// <summary>
+    /// Apply table of contents configuration
+    /// </summary>
+    /// <param name="config">Conversion configuration containing TOC settings</param>
+    /// <returns>Table of contents style</returns>
+    TableOfContentsStyle ApplyTableOfContentsStyle(ConversionConfiguration config);
 }

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/ConversionConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/ConversionConfiguration.cs
@@ -41,6 +41,11 @@ public sealed class ConversionConfiguration
     /// Text transformation rules (optional, for vertical text)
     /// </summary>
     public TransformationRules? Transformations { get; init; }
+
+    /// <summary>
+    /// Table of contents configuration
+    /// </summary>
+    public TableOfContentsConfig TableOfContents { get; init; } = new();
 }
 
 /// <summary>
@@ -139,6 +144,32 @@ public sealed class FontConfig
     /// Default font size in pt
     /// </summary>
     public int DefaultSize { get; init; }
+}
+
+/// <summary>
+/// Table of contents configuration
+/// </summary>
+public sealed class TableOfContentsConfig
+{
+    /// <summary>
+    /// Whether TOC generation is enabled
+    /// </summary>
+    public bool Enabled { get; init; } = false;
+
+    /// <summary>
+    /// Heading depth to include (1-6, e.g., 3 = H1-H3)
+    /// </summary>
+    public int Depth { get; init; } = 3;
+
+    /// <summary>
+    /// Optional title displayed above the TOC (null or empty = no title)
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Whether to insert a page break after the TOC
+    /// </summary>
+    public bool PageBreakAfter { get; init; } = false;
 }
 
 /// <summary>

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -120,4 +120,21 @@ public sealed class StyleApplicator : IStyleApplicator
             SpaceAfter = config.Quote.SpaceAfter
         };
     }
+
+    /// <inheritdoc/>
+    public TableOfContentsStyle ApplyTableOfContentsStyle(ConversionConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var tocConfig = config.TableOfContents;
+        var depth = Math.Clamp(tocConfig.Depth, 1, 6);
+
+        return new TableOfContentsStyle
+        {
+            Enabled = tocConfig.Enabled,
+            Depth = depth,
+            Title = tocConfig.Title,
+            PageBreakAfter = tocConfig.PageBreakAfter
+        };
+    }
 }

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/YamlConfigurationLoaderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/YamlConfigurationLoaderTests.cs
@@ -145,6 +145,23 @@ public class YamlConfigurationLoaderTests
     }
 
     [Fact]
+    public void LoadPreset_WithMinimalPreset_ShouldHaveTableOfContentsConfig()
+    {
+        // Arrange
+        const string presetName = "minimal";
+
+        // Act
+        var config = _loader.LoadPreset(presetName);
+
+        // Assert
+        config.TableOfContents.Should().NotBeNull();
+        config.TableOfContents.Enabled.Should().BeFalse();
+        config.TableOfContents.Depth.Should().Be(3);
+        config.TableOfContents.Title.Should().Be("Contents");
+        config.TableOfContents.PageBreakAfter.Should().BeTrue();
+    }
+
+    [Fact]
     public void LoadPreset_WithNonExistentPreset_ShouldThrowFileNotFoundException()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Add TOC generation using Word field codes (`TOC \o \h \z \u`) with YAML-configurable depth, title, and page break options
- TOC is populated by Word when the document is opened ("Update fields" prompt)
- Builds on outline level support from #8

## YAML Configuration
```yaml
TableOfContents:
  Enabled: false          # default: disabled
  Depth: 3                # H1-H3 (range: 1-6)
  Title: "Contents"       # empty/omitted = no title
  PageBreakAfter: true    # page break after TOC
```

## Changes
- New `TableOfContentsStyle` model in Core
- `TableOfContentsConfig` in ConversionConfiguration (top-level, not under Styles)
- `AddTableOfContents()` on IDocumentBuilder/OpenXmlDocumentBuilder
- `ApplyTableOfContentsStyle()` on IStyleApplicator/StyleApplicator with depth clamping
- 13 new tests across OpenXmlDocumentBuilder, StyleApplicator, and YamlConfigurationLoader
- Updated `minimal.yaml` preset with TOC section (disabled by default)

## Test plan
- [x] `dotnet test` — 123/123 tests pass
- [x] Existing tests unaffected (TOC disabled by default)
- [ ] Manual: open generated DOCX in Word, confirm "Update fields" prompt shows TOC

Closes #6