### PR TITLE
fix: center title page image and improve TOC for KDP compatibility

### DIFF
--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -921,6 +921,10 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         instrText.Should().NotBeNull();
         instrText!.Text.Should().Contain("TOC");
         instrText.Text.Should().Contain("1-3");
+
+        // Should have placeholder text between separate and end markers
+        var texts = body.Descendants<Text>().ToList();
+        texts.Should().Contain(t => t.Text.Contains("Update Field"));
     }
 
     [Theory]
@@ -979,7 +983,9 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         _stream.Position = 0;
         using var doc = WordprocessingDocument.Open(_stream, false);
         var texts = doc.MainDocumentPart!.Document.Body!.Descendants<Text>().ToList();
-        texts.Should().BeEmpty();
+        // No title text, only placeholder instruction text
+        texts.Should().NotContain(t => t.Text == "Contents");
+        texts.Should().Contain(t => t.Text.Contains("Update Field"));
     }
 
     [Fact]

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/TitlePageTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/TitlePageTests.cs
@@ -124,10 +124,10 @@ public class TitlePageTests : IDisposable
         var body = doc.MainDocumentPart!.Document.Body!;
         var paragraphs = body.Elements<Paragraph>().ToList();
 
-        // Should have 2 paragraphs: image paragraph + page break paragraph
-        paragraphs.Should().HaveCount(2);
+        // Should have 1 paragraph: image with section break (not a separate page break paragraph)
+        paragraphs.Should().HaveCount(1);
 
-        // First paragraph should be centered with a Drawing element
+        // Paragraph should be centered with a Drawing element
         var imageParagraph = paragraphs[0];
         var justification = imageParagraph.ParagraphProperties?.Justification;
         justification.Should().NotBeNull();
@@ -136,11 +136,17 @@ public class TitlePageTests : IDisposable
         var drawing = imageParagraph.Descendants<Drawing>().FirstOrDefault();
         drawing.Should().NotBeNull();
 
-        // Second paragraph should have page break
-        var breakParagraph = paragraphs[1];
-        var pageBreak = breakParagraph.Descendants<Break>().FirstOrDefault();
-        pageBreak.Should().NotBeNull();
-        pageBreak!.Type!.Value.Should().Be(BreakValues.Page);
+        // Section break with vertical centering should be in paragraph properties
+        var sectionProps = imageParagraph.ParagraphProperties?.Elements<SectionProperties>().FirstOrDefault();
+        sectionProps.Should().NotBeNull();
+
+        var vAlign = sectionProps!.Elements<VerticalTextAlignmentOnPage>().FirstOrDefault();
+        vAlign.Should().NotBeNull();
+        vAlign!.Val!.Value.Should().Be(VerticalJustificationValues.Center);
+
+        var sectionType = sectionProps.Elements<SectionType>().FirstOrDefault();
+        sectionType.Should().NotBeNull();
+        sectionType!.Val!.Value.Should().Be(SectionMarkValues.NextPage);
 
         // Should have an image part
         doc.MainDocumentPart.ImageParts.Should().HaveCount(1);


### PR DESCRIPTION
## Summary
- Center title page cover image both horizontally and vertically using section break with `VerticalTextAlignmentOnPage.Center`
- Add English placeholder text in TOC field to guide users to update the field
- Remove `\h` and `\z` switches from TOC field code to eliminate hyperlinks for KDP PDF compatibility

Closes #7

## Test plan
- [x] All 160 tests pass
- [x] Manual test: cover image centered on page (horizontal + vertical)
- [x] Manual test: TOC shows placeholder text, updates correctly in Word
- [x] Manual test: PDF export produces clean TOC without hyperlinks