### PR TITLE
fix: set ListStyleConfig.Size default to 10pt to prevent invisible list text

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -171,9 +171,10 @@ public sealed class ParagraphStyleConfig
 public sealed class ListStyleConfig
 {
     /// <summary>
-    /// Font size in points (pt)
+    /// Font size in points (pt). Defaults to 10pt to prevent invisible text
+    /// when the YAML key is misconfigured (e.g. "ListItem" instead of "List").
     /// </summary>
-    public int Size { get; init; }
+    public int Size { get; init; } = 10;
 
     /// <summary>
     /// Text color in hex format (e.g., "000000" for black)

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
@@ -212,6 +212,24 @@ public class StyleApplicatorTests
     }
 
     [Fact]
+    public void ApplyListStyle_WithDefaultConfig_ShouldReturnReadableFontSize()
+    {
+        // Arrange - simulate misconfigured YAML (e.g. "ListItem" key used instead of "List")
+        // YamlDotNet silently ignores unmatched keys, leaving ListStyleConfig at defaults
+        var config = new StyleConfiguration
+        {
+            List = new ListStyleConfig() // no Size set — uses default
+        };
+
+        // Act
+        var style = _applicator.ApplyListStyle(config);
+
+        // Assert: default Size=10 must result in readable (non-zero) FontSize
+        style.FontSize.Should().Be(10 * 2); // 10pt = 20 half-points
+        style.FontSize.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
     public void ApplyCodeBlockStyle_ShouldReturnCorrectStyle()
     {
         // Act


### PR DESCRIPTION
## Summary

- Set `ListStyleConfig.Size` default from `0` to `10` (pt)
- Prevents list items from rendering as invisible/tiny text when YAML preset uses wrong key (e.g. `ListItem` instead of `List`)
- Adds regression test verifying safe-default behavior

## Root Cause

`YamlConfigurationLoader` uses `.IgnoreUnmatchedProperties()`, so a misconfigured YAML key is silently ignored and `ListStyleConfig` falls back to its defaults. With `Size = 0`, `StyleApplicator` computes `FontSize = 0 * 2 = 0`, which passes `w:sz = 0` to OpenXML — rendering list items nearly invisible in Word.

## Test Plan

- [x] All 188 existing tests pass
- [x] New test: `ApplyListStyle_WithDefaultConfig_ShouldReturnReadableFontSize` verifies `FontSize = 20` (10pt) when `Size` is not set
- [x] Build: 0 warnings, 0 errors
- [x] Pre-push validation passed

Fixes #19