### PR TITLE
fix: make code block border Space configurable via YAML (was hardcoded to 8pt)

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/Models/CodeBlockStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/CodeBlockStyle.cs
@@ -49,4 +49,10 @@ public sealed record CodeBlockStyle
     /// Line spacing within code block
     /// </summary>
     public string LineSpacing { get; init; } = "240";
+
+    /// <summary>
+    /// Distance between the border line and the text in points (OpenXML Space attribute).
+    /// Applied to all four sides of the code block border.
+    /// </summary>
+    public uint BorderSpace { get; init; } = 4;
 }

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -665,10 +665,10 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
 
         // Borders
         props.AppendChild(new ParagraphBorders(
-            new TopBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = 8 },
-            new BottomBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = 8 },
-            new LeftBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = 8 },
-            new RightBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = 8 }
+            new TopBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = style.BorderSpace },
+            new BottomBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = style.BorderSpace },
+            new LeftBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = style.BorderSpace },
+            new RightBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = 4, Space = style.BorderSpace }
         ));
 
         // Background shading

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -251,6 +251,13 @@ public sealed class CodeBlockStyleConfig
     /// Spacing after code block in twips (1/20 of a point)
     /// </summary>
     public string SpaceAfter { get; init; } = "240";
+
+    /// <summary>
+    /// Distance between the border line and the text in points (default: 4).
+    /// Controls internal padding on all four sides of the code block border.
+    /// Reducing this value makes single-line code blocks appear more compact.
+    /// </summary>
+    public uint BorderSpace { get; init; } = 4;
 }
 
 /// <summary>

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -96,7 +96,8 @@ public sealed class StyleApplicator : IStyleApplicator
             MonospaceFontEastAsia = config.CodeBlock.MonospaceFontEastAsia,
             LineSpacing = config.CodeBlock.LineSpacing,
             SpaceBefore = config.CodeBlock.SpaceBefore,
-            SpaceAfter = config.CodeBlock.SpaceAfter
+            SpaceAfter = config.CodeBlock.SpaceAfter,
+            BorderSpace = config.CodeBlock.BorderSpace
         };
     }
 

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -354,6 +354,31 @@ public class OpenXmlDocumentBuilderTests : IDisposable
     }
 
     [Fact]
+    public void AddCodeBlock_ShouldUseBorderSpaceFromStyle()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultCodeBlockStyle() with { BorderSpace = 2U };
+
+        // Act
+        builder.AddCodeBlock("echo hello", null, style);
+        builder.Save();
+
+        // Assert: all four paragraph borders must carry Space = 2
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var borders = paragraph.ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<TopBorder>()!.Space!.Value.Should().Be(2U);
+        borders.GetFirstChild<BottomBorder>()!.Space!.Value.Should().Be(2U);
+        borders.GetFirstChild<LeftBorder>()!.Space!.Value.Should().Be(2U);
+        borders.GetFirstChild<RightBorder>()!.Space!.Value.Should().Be(2U);
+    }
+
+    [Fact]
     public void AddQuote_WithNullText_ShouldThrowArgumentNullException()
     {
         // Arrange

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
@@ -246,6 +246,43 @@ public class StyleApplicatorTests
     }
 
     [Fact]
+    public void ApplyCodeBlockStyle_ShouldMapBorderSpace()
+    {
+        // Arrange
+        var config = new StyleConfiguration
+        {
+            CodeBlock = new CodeBlockStyleConfig
+            {
+                Size = 9,
+                Color = "000000",
+                BorderSpace = 2
+            }
+        };
+
+        // Act
+        var style = _applicator.ApplyCodeBlockStyle(config);
+
+        // Assert
+        style.BorderSpace.Should().Be(2U);
+    }
+
+    [Fact]
+    public void ApplyCodeBlockStyle_WithDefaultBorderSpace_ShouldBeFour()
+    {
+        // Arrange - default CodeBlockStyleConfig
+        var config = new StyleConfiguration
+        {
+            CodeBlock = new CodeBlockStyleConfig { Size = 9, Color = "000000" }
+        };
+
+        // Act
+        var style = _applicator.ApplyCodeBlockStyle(config);
+
+        // Assert: default BorderSpace=4, not the old hardcoded 8
+        style.BorderSpace.Should().Be(4U);
+    }
+
+    [Fact]
     public void ApplyQuoteStyle_ShouldReturnCorrectStyle()
     {
         // Act


### PR DESCRIPTION
## Summary

- Add `BorderSpace` property to `CodeBlockStyle` (Core model) and `CodeBlockStyleConfig` (YAML model)
- Replace hardcoded `Space = 8` in `OpenXmlDocumentBuilder.CreateCodeBlockParagraphProperties` with `style.BorderSpace`
- Default changed from 8 → 4 (more compact, still readable)
- Map through `StyleApplicator.ApplyCodeBlockStyle`

## Root Cause

The `Space` attribute on OpenXML `ParagraphBorders` controls the distance (in points) between the border line and the text. The previous hardcoded value of `8` caused single-line code blocks to appear disproportionately tall in Word. Unlike headings and quotes — which already expose `BorderSpace` via YAML — code blocks had no equivalent configurable property.

## YAML Usage After Fix

```yaml
Styles:
  CodeBlock:
    BorderSpace: 1   # compact (tight padding)
    # BorderSpace: 4  # default (balanced)
    # BorderSpace: 8  # previous behaviour
```

## Test Plan

- [x] All 191 tests pass (3 new tests added)
- [x] `ApplyCodeBlockStyle_ShouldMapBorderSpace` — verifies custom value is passed through
- [x] `ApplyCodeBlockStyle_WithDefaultBorderSpace_ShouldBeFour` — verifies default is 4 (not 8)
- [x] `AddCodeBlock_ShouldUseBorderSpaceFromStyle` — verifies OpenXML Space attribute matches style value
- [x] Build: 0 warnings, 0 errors
- [x] Pre-push validation passed

Fixes #18