### PR TITLE
docs: sync documentation with v0.2.1 source code and features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2026-02-18
+## [0.2.1] - 2026-02-25
+
+### Added
+
+#### Inline Image Support
+- **Inline image rendering** in body content via standard Markdown syntax (`![alt](path)`)
+- Images are embedded directly into the DOCX using `AddImage(path, altText, style)`
+- Proportional scaling: images are scaled to fit `MaxWidthPercent` of the printable width while preserving aspect ratio
+- New `Image` style configuration section in YAML: `MaxWidthPercent` (default: 100) and `Alignment` (default: `"center"`)
+- Image paths resolved relative to the input Markdown file directory
+- Supported formats: PNG and JPEG (reuses existing `ImageDimensionReader`)
+- Unique `DocProperties.Id` per image via internal counter (prevents corrupt DOCX with multiple images)
+
+#### CodeBlock BorderSpace Configuration
+- New `BorderSpace` property on `CodeBlock` style: controls spacing between border and text (in points)
+- Default value: `4` (previously hardcoded to `8`, which produced excessive padding)
+- Propagated through all layers: YAML → `CodeBlockStyleConfig` → `StyleApplicator` → `CodeBlockStyle` → `OpenXmlDocumentBuilder`
+
+### Fixed
+
+- **ListStyleConfig.Size default** changed from `0` to `10`: previously, if the YAML key was misnamed (e.g. `ListItem` instead of `List`), YamlDotNet silently ignored it leaving `Size=0`, resulting in invisible list text
 
 ### Improved
 
 #### Test Coverage
+- Added **15 new tests** (total: 202, up from 187)
+- `StyleApplicatorTests`: 4 new tests for `ApplyImageStyle` (defaults, custom config, clamp, null guard) and 1 test for `ApplyListStyle` default size
+- `StyleApplicatorTests`: 2 new tests for `ApplyCodeBlockStyle` (BorderSpace mapping, default value)
+- `OpenXmlDocumentBuilderTests`: 5 new tests for `AddImage` (null path, null alt text, missing file, valid PNG embed, multiple images)
+
+#### Earlier Test Coverage (2026-02-18)
 - Added **27 new tests** (total: 187, up from 160)
 - `ImageDimensionReader`: 9 edge case tests covering truncated files, invalid signatures, progressive JPEG, FF padding, and truncated segments
-- `YamlConfigurationLoader`: 10 validation tests covering all `ValidateConfiguration` branches (invalid YAML, empty schema version, missing metadata, zero page dimensions, missing fonts)
-- `OpenXmlDocumentBuilder`: 8 tests for remaining uncovered branches (right/top/all border positions, quote ShowBorder=false, quote BackgroundColor, heading LineSpacing, BorderExtent spacer skip)
+- `YamlConfigurationLoader`: 10 validation tests covering all `ValidateConfiguration` branches
+- `OpenXmlDocumentBuilder`: 8 tests for remaining uncovered branches
 
 #### Build Quality
 - Resolved all build warnings (previously ~62 warnings, now 0)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Markdown to Word Converter
 
-[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/forest6511/md2docx/releases)
+[![Version](https://img.shields.io/badge/version-0.2.1-blue.svg)](https://github.com/forest6511/md2docx/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/)
-[![Tests](https://img.shields.io/badge/tests-160%20passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-202%20passing-brightgreen.svg)]()
 [![Coverage](https://img.shields.io/badge/coverage-90%25+-brightgreen.svg)]()
 
 **A flexible, high-quality Markdown to Word (DOCX) converter with YAML-based styling customization.**
@@ -158,10 +158,10 @@ Perfect for:
 - Horizontal rules (thematic breaks)
 - Table of Contents (auto-generated with configurable depth)
 - Cover/Title page with centered image
+- Inline images (PNG/JPEG with configurable max width and alignment)
 
 🚧 **Planned for Future Releases**:
 - Tables
-- Inline images
 - Inline code
 - Links
 - Task lists
@@ -237,6 +237,7 @@ Styles:
     BorderColor: "bdc3c7"
     MonospaceFontAscii: "Noto Sans Mono"
     MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    BorderSpace: 4
     ShowBorder: true
 ```
 
@@ -337,7 +338,7 @@ md2docx/
 cd csharp-version
 dotnet test
 
-# Current test coverage: 160 tests passing
+# Current test coverage: 202 tests passing
 # - Core layer: Unit tests for builder, parser, imaging
 # - Styling layer: Unit tests for config loader, style applicator
 # - Integration: End-to-end conversion tests
@@ -361,7 +362,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 ### Areas for Contribution
 
 - **Presets**: Create new YAML presets for specific use cases
-- **Features**: Implement tables, images, inline code, links
+- **Features**: Implement tables, inline code, links, nested lists
 - **Bug Fixes**: Report and fix issues
 - **Documentation**: Improve docs, add examples
 - **Testing**: Add test cases, improve coverage

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -234,7 +234,23 @@ Styles:
     SpaceAfter: "300"                    # Space after
     ShowBorder: true                     # Display border
     BorderSize: 4                        # Border thickness
+    BorderSpace: 4                       # Space between border and text (in points)
 ```
+
+#### Image Style
+
+```yaml
+Styles:
+  Image:
+    MaxWidthPercent: 100        # Max width as % of printable area (1-100)
+    Alignment: "center"         # "left", "center", or "right"
+```
+
+**Notes**:
+- **Supported formats**: PNG and JPEG
+- **MaxWidthPercent**: The image is scaled proportionally to fit within this percentage of the printable width. Defaults to `100`.
+- **Alignment**: Controls paragraph alignment for the image. Defaults to `"center"`.
+- Image paths in Markdown are resolved relative to the input `.md` file directory.
 
 #### Quote Block Style
 
@@ -430,4 +446,4 @@ See `config/presets/default.yaml` for a complete, well-commented example configu
 
 ---
 
-**Last Updated**: 2026-02-17
+**Last Updated**: 2026-02-25

--- a/docs/en/presets.md
+++ b/docs/en/presets.md
@@ -316,4 +316,4 @@ View the complete source files for detailed styling specifications.
 
 ---
 
-**Last Updated**: 2026-02-17
+**Last Updated**: 2026-02-25

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -232,7 +232,23 @@ Styles:
     SpaceAfter: "300"                    # 後の間隔
     ShowBorder: true                     # 枠線を表示
     BorderSize: 4                        # 枠線の太さ
+    BorderSpace: 4                       # 枠線とテキスト間の余白（ポイント）
 ```
+
+#### 画像スタイル
+
+```yaml
+Styles:
+  Image:
+    MaxWidthPercent: 100        # 印刷可能領域に対する最大幅（%、1-100）
+    Alignment: "center"         # "left"、"center"、"right"
+```
+
+**注意**：
+- **対応フォーマット**：PNGおよびJPEG
+- **MaxWidthPercent**：画像は印刷可能幅のこの割合に収まるよう比例縮小されます。デフォルトは `100`。
+- **Alignment**：画像を含む段落の配置を制御します。デフォルトは `"center"`。
+- Markdownで指定した画像パスは、入力 `.md` ファイルのディレクトリからの相対パスで解決されます。
 
 #### 引用ブロックスタイル
 
@@ -428,4 +444,4 @@ ruby -e "require 'yaml'; YAML.load_file('config/custom/my-style.yaml')"
 
 ---
 
-**最終更新**: 2026-02-17
+**最終更新**: 2026-02-25

--- a/docs/ja/presets.md
+++ b/docs/ja/presets.md
@@ -316,4 +316,4 @@ docker run --rm -v $(pwd):/workspace forest6511/md2docx:latest \
 
 ---
 
-**最終更新**: 2026-02-17
+**最終更新**: 2026-02-25


### PR DESCRIPTION
## Summary

- Update README: version badge 0.2.0→0.2.1, tests badge 160→202
- Move inline images from planned to supported in README
- Add `BorderSpace` property to CodeBlock YAML examples (README and docs)
- Add new `Image` style section to configuration docs (EN + JA)
- Expand CHANGELOG v0.2.1 entry with inline image support, BorderSpace, and ListStyleConfig fix
- Update Last Updated dates across all docs pages

## Test plan

- [x] Version numbers consistent: 0.2.1 across all files (verified by pre-push hook)
- [x] Build passes (0 warnings, 0 errors)
- [x] All 202 tests passing
- [x] Documentation consistency check passed