### PR TITLE
fix: resolve broken 'View on GitHub' link on GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,8 @@ title: md2docx
 description: Flexible Markdown to Word (DOCX) converter with YAML-based styling
 baseurl: "/md2docx"
 url: "https://forest6511.github.io"
+repository: forest6511/md2docx
+github_url: "https://github.com/forest6511/md2docx"
 
 # Build settings
 theme: jekyll-theme-cayman

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,7 +23,7 @@
         <a href="{{ site.baseurl }}/ja/" class="btn">ドキュメント</a>
         <a href="{{ site.baseurl }}/en/" class="btn">English</a>
       {% endif %}
-      <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
+      <a href="{{ site.github.repository_url | default: site.github_url }}" class="btn">View on GitHub</a>
       {% if site.github.is_project_page %}
         <a href="{{ site.github.releases_url }}" class="btn">Releases</a>
       {% endif %}


### PR DESCRIPTION
## Summary

- Add `repository: forest6511/md2docx` to `docs/_config.yml` so jekyll-github-metadata populates `site.github.repository_url`
- Add `github_url` as an explicit fallback URL in `_config.yml`
- Update `_layouts/default.html` to use `site.github_url` as fallback when `site.github.repository_url` is empty

## Root Cause

The "View on GitHub" button linked to an empty href because `site.github.repository_url` was not being populated. Adding the `repository` key to `_config.yml` allows the Jekyll GitHub metadata plugin to resolve this correctly, with an explicit URL as a safety fallback.

## Test plan

- [x] Build passes
- [x] All 202 tests passing
- [x] Link will be verified after GitHub Pages redeploys