### PR TITLE
fix: reduce default Quote SpaceBefore/SpaceAfter from 240 to 120 twips

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/Models/QuoteStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/QuoteStyle.cs
@@ -58,10 +58,10 @@ public sealed record QuoteStyle
     /// <summary>
     /// Space before quote in twips
     /// </summary>
-    public string SpaceBefore { get; init; } = "200";
+    public string SpaceBefore { get; init; } = "120";
 
     /// <summary>
     /// Space after quote in twips
     /// </summary>
-    public string SpaceAfter { get; init; } = "200";
+    public string SpaceAfter { get; init; } = "120";
 }

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -328,12 +328,12 @@ public sealed class QuoteStyleConfig
     /// <summary>
     /// Spacing before quote block in twips (1/20 of a point)
     /// </summary>
-    public string SpaceBefore { get; init; } = "240";
+    public string SpaceBefore { get; init; } = "120";
 
     /// <summary>
     /// Spacing after quote block in twips (1/20 of a point)
     /// </summary>
-    public string SpaceAfter { get; init; } = "240";
+    public string SpaceAfter { get; init; } = "120";
 }
 
 /// <summary>

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
@@ -300,6 +300,23 @@ public class StyleApplicatorTests
     }
 
     [Fact]
+    public void ApplyQuoteStyle_WithDefaultConfig_ShouldHaveCompactSpacing()
+    {
+        // Arrange - use default QuoteStyleConfig (no explicit SpaceBefore/SpaceAfter)
+        var config = new StyleConfiguration
+        {
+            Quote = new QuoteStyleConfig()
+        };
+
+        // Act
+        var style = _applicator.ApplyQuoteStyle(config);
+
+        // Assert: default spacing should be 120 twips (6pt), not 240 (12pt)
+        style.SpaceBefore.Should().Be("120");
+        style.SpaceAfter.Should().Be("120");
+    }
+
+    [Fact]
     public void ApplyImageStyle_WithDefaultConfig_ShouldReturnDefaults()
     {
         // Act


### PR DESCRIPTION
## Summary

- Reduce `QuoteStyleConfig.SpaceBefore` and `SpaceAfter` defaults from `"240"` to `"120"` twips
- Reduce `QuoteStyle.SpaceBefore` and `SpaceAfter` defaults from `"200"` to `"120"` twips

## Problem

240 twips (12pt) of spacing around blockquotes was visually indistinguishable from an empty paragraph, making documents look like they had spurious blank lines. Investigation confirmed no extra paragraphs were generated — the issue was purely the default spacing value.

## Test plan

- [x] All 208 tests pass (207 existing + 1 new)
- [x] New regression test: default `QuoteStyleConfig` produces `SpaceBefore = "120"` and `SpaceAfter = "120"`

Closes #27