### PR TITLE
feat: add PaddingSpace to blockquote for internal padding (#33)

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/Models/QuoteStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/QuoteStyle.cs
@@ -64,4 +64,12 @@ public sealed record QuoteStyle
     /// Space after quote in twips
     /// </summary>
     public string SpaceAfter { get; init; } = "120";
+
+    /// <summary>
+    /// Internal padding on top, right, and bottom in points.
+    /// Creates invisible borders matching the background color to produce
+    /// spacing between the background fill and the text content.
+    /// Only effective when BackgroundColor is set.
+    /// </summary>
+    public uint PaddingSpace { get; init; } = 0;
 }

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -795,14 +795,42 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     {
         var props = CreateBaseParagraphProperties();
 
-        // Border
-        if (style.ShowBorder)
+        // Border and/or padding
+        bool hasPadding = style.PaddingSpace > 0 && !string.IsNullOrEmpty(style.BackgroundColor);
+        if (style.ShowBorder || hasPadding)
         {
-            props.AppendChild(CreateBordersFromPositions(
-                style.BorderPosition,
-                style.BorderColor,
-                style.BorderSize,
-                style.BorderSpace));
+            var borders = new ParagraphBorders();
+
+            if (style.ShowBorder)
+            {
+                var positions = style.BorderPosition
+                    .ToLowerInvariant()
+                    .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                foreach (var pos in positions)
+                {
+                    OpenXmlElement border = pos switch
+                    {
+                        "left" => new LeftBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = style.BorderSize, Space = style.BorderSpace },
+                        "right" => new RightBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = style.BorderSize, Space = style.BorderSpace },
+                        "top" => new TopBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = style.BorderSize, Space = style.BorderSpace },
+                        _ => new BottomBorder { Val = BorderValues.Single, Color = style.BorderColor, Size = style.BorderSize, Space = style.BorderSpace }
+                    };
+                    borders.AppendChild(border);
+                }
+            }
+
+            if (hasPadding)
+            {
+                // Add invisible padding borders on top/right/bottom (skip positions already occupied by visible border)
+                if (borders.GetFirstChild<TopBorder>() == null)
+                    borders.AppendChild(new TopBorder { Val = BorderValues.Single, Color = style.BackgroundColor!, Size = 4, Space = style.PaddingSpace });
+                if (borders.GetFirstChild<RightBorder>() == null)
+                    borders.AppendChild(new RightBorder { Val = BorderValues.Single, Color = style.BackgroundColor!, Size = 4, Space = style.PaddingSpace });
+                if (borders.GetFirstChild<BottomBorder>() == null)
+                    borders.AppendChild(new BottomBorder { Val = BorderValues.Single, Color = style.BackgroundColor!, Size = 4, Space = style.PaddingSpace });
+            }
+
+            props.AppendChild(borders);
         }
 
         // Background shading

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -334,6 +334,12 @@ public sealed class QuoteStyleConfig
     /// Spacing after quote block in twips (1/20 of a point)
     /// </summary>
     public string SpaceAfter { get; init; } = "120";
+
+    /// <summary>
+    /// Internal padding on top, right, and bottom in points (default: 0 = no padding).
+    /// Only effective when BackgroundColor is set.
+    /// </summary>
+    public uint PaddingSpace { get; init; } = 0;
 }
 
 /// <summary>

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -120,7 +120,8 @@ public sealed class StyleApplicator : IStyleApplicator
             BackgroundColor = config.Quote.BackgroundColor,
             LeftIndent = config.Quote.LeftIndent,
             SpaceBefore = config.Quote.SpaceBefore,
-            SpaceAfter = config.Quote.SpaceAfter
+            SpaceAfter = config.Quote.SpaceAfter,
+            PaddingSpace = config.Quote.PaddingSpace
         };
     }
 

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -1637,6 +1637,73 @@ public class OpenXmlDocumentBuilderTests : IDisposable
     }
 
     [Fact]
+    public void AddQuote_WithPaddingSpaceAndBackground_ShouldRenderInvisiblePaddingBorders()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new QuoteStyle
+        {
+            FontSize = 22,
+            Color = "555555",
+            Italic = false,
+            ShowBorder = true,
+            BorderPosition = "left",
+            BorderColor = "3498db",
+            BorderSize = 24,
+            BackgroundColor = "f0f4f8",
+            LeftIndent = "720",
+            SpaceBefore = "120",
+            SpaceAfter = "120",
+            PaddingSpace = 4
+        };
+
+        // Act
+        builder.AddQuote("Padded quote", style);
+        builder.Save();
+
+        // Assert: top/right/bottom invisible borders should be present with background color
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        var borders = paragraph.ParagraphProperties?.ParagraphBorders;
+        borders.Should().NotBeNull();
+        borders!.GetFirstChild<TopBorder>()!.Space!.Value.Should().Be(4U);
+        borders.GetFirstChild<TopBorder>()!.Color!.Value.Should().Be("f0f4f8");
+        borders.GetFirstChild<RightBorder>()!.Space!.Value.Should().Be(4U);
+        borders.GetFirstChild<BottomBorder>()!.Space!.Value.Should().Be(4U);
+        // Left border should remain the visible border
+        borders.GetFirstChild<LeftBorder>()!.Color!.Value.Should().Be("3498db");
+    }
+
+    [Fact]
+    public void AddQuote_WithPaddingSpaceButNoBackground_ShouldNotRenderPaddingBorders()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = new QuoteStyle
+        {
+            FontSize = 22,
+            Color = "555555",
+            ShowBorder = false,
+            BackgroundColor = null,
+            LeftIndent = "720",
+            SpaceBefore = "120",
+            SpaceAfter = "120",
+            PaddingSpace = 4  // should be ignored without background
+        };
+
+        // Act
+        builder.AddQuote("No padding without background", style);
+        builder.Save();
+
+        // Assert: no borders rendered when ShowBorder=false and no BackgroundColor
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        paragraph.ParagraphProperties?.ParagraphBorders.Should().BeNull();
+    }
+
+    [Fact]
     public void AddHeading_WithLineSpacing_ShouldRenderExactSpacing()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- Add `PaddingSpace` property (`uint`, default `0`) to `QuoteStyle` and `QuoteStyleConfig`
- When `BackgroundColor` is set and `PaddingSpace > 0`, invisible borders are added on top/right/bottom sides using the background color as the border color, creating internal padding between the background fill and the text

## How it works

Word's paragraph border `w:space` attribute creates a gap between the border line and the paragraph text. By using a border color that matches the background fill, the border becomes visually invisible while still providing the spacing.

```yaml
quote:
  background_color: "f0f4f8"
  padding_space: 4    # pt — top/right/bottom internal padding
  show_border: true
  border_position: left
  border_space: 8     # pt — gap between left border line and text
```

## Behaviour

| Condition | Result |
|-----------|--------|
| `PaddingSpace > 0` and `BackgroundColor` set | Invisible padding borders on top/right/bottom |
| `PaddingSpace > 0` but no `BackgroundColor` | No effect (padding ignored) |
| `PaddingSpace = 0` (default) | No change from previous behaviour |

## Test plan

- [x] All 213 tests pass (208 existing + 5 new from recent branches + 2 new here)
- [x] `PaddingSpace=4` with background → top/right/bottom invisible borders with correct `Space` and `Color`
- [x] `PaddingSpace=4` without background → no padding borders rendered
- [x] Visible left border still renders with original `BorderColor` alongside padding borders

Closes #33