### PR TITLE
fix: preserve ordered list numbering when interrupted by a code block (#34)

### DIFF
--- a/csharp-version/src/MarkdownToDocx.CLI/Program.cs
+++ b/csharp-version/src/MarkdownToDocx.CLI/Program.cs
@@ -116,7 +116,8 @@ try
                     var items = Helpers.GetListItems(list);
                     var isOrdered = list.IsOrdered;
                     var listStyle = styleApplicator.ApplyListStyle(config.Styles);
-                    builder.AddList(items, isOrdered, listStyle);
+                    var startNumber = int.TryParse(list.OrderedStart, out var parsed) ? parsed : 1;
+                    builder.AddList(items, isOrdered, listStyle, startNumber);
                     break;
 
                 case QuoteBlock quote:

--- a/csharp-version/src/MarkdownToDocx.Core/Interfaces/IDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Interfaces/IDocumentBuilder.cs
@@ -28,7 +28,8 @@ public interface IDocumentBuilder : IDisposable
     /// <param name="items">List items</param>
     /// <param name="isOrdered">True for numbered list, false for bullet list</param>
     /// <param name="style">List style configuration</param>
-    void AddList(IEnumerable<ListItem> items, bool isOrdered, ListStyle style);
+    /// <param name="startNumber">First number for ordered lists (default: 1)</param>
+    void AddList(IEnumerable<ListItem> items, bool isOrdered, ListStyle style, int startNumber = 1);
 
     /// <summary>
     /// Adds a code block to the document

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -662,12 +662,12 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     }
 
     /// <inheritdoc/>
-    public void AddList(IEnumerable<CoreListItem> items, bool isOrdered, ListStyle style)
+    public void AddList(IEnumerable<CoreListItem> items, bool isOrdered, ListStyle style, int startNumber = 1)
     {
         ArgumentNullException.ThrowIfNull(items);
         ArgumentNullException.ThrowIfNull(style);
 
-        int itemNumber = 1;
+        int itemNumber = startNumber;
         foreach (var item in items)
         {
             var paragraph = _body.AppendChild(new Paragraph());

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -305,6 +305,36 @@ public class OpenXmlDocumentBuilderTests : IDisposable
     }
 
     [Fact]
+    public void AddList_WithOrderedListAndStartNumber_ShouldBeginFromSpecifiedNumber()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var items = new List<CoreListItem>
+        {
+            new CoreListItem { Text = "Individual settings" },
+            new CoreListItem { Text = "Project settings" },
+            new CoreListItem { Text = "Local override" }
+        };
+        var style = CreateDefaultListStyle();
+
+        // Act - simulate a list starting at 2 (interrupted by a code block)
+        builder.AddList(items, true, style, startNumber: 2);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var textContent = string.Join("", doc.MainDocumentPart!.Document.Body!
+            .Descendants<Text>()
+            .Select(t => t.Text));
+
+        textContent.Should().Contain("2. Individual settings");
+        textContent.Should().Contain("3. Project settings");
+        textContent.Should().Contain("4. Local override");
+        textContent.Should().NotContain("1. Individual settings");
+    }
+
+    [Fact]
     public void AddCodeBlock_WithNullCode_ShouldThrowArgumentNullException()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- Fixes #34
- When a code block appears between ordered list items, Markdig splits them into separate `ListBlock` nodes, each with an `OrderedStart` property indicating the resume number
- Previously `AddList()` always started from 1, rendering every segment as "1. …"

## Changes

- `IDocumentBuilder.AddList()` gains optional `startNumber` parameter (default 1 — no breaking change)
- `OpenXmlDocumentBuilder.AddList()` initialises `itemNumber = startNumber`
- `Program.cs` parses `list.OrderedStart` and forwards it as `startNumber`

## Test plan

- [x] `AddList_WithOrderedListAndStartNumber_ShouldBeginFromSpecifiedNumber` (new) — verifies items start at 2, 3, 4
- [x] All 212 tests pass