### PR TITLE
feat: add standard book trim size presets

### DIFF
--- a/csharp-version/config/presets/5.5x8.5-en.yaml
+++ b/csharp-version/config/presets/5.5x8.5-en.yaml
@@ -1,0 +1,120 @@
+# 5.5x8.5 inch English non-fiction preset (139.7x215.9mm)
+# Suitable for: non-fiction, textbooks, academic books
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "5.5x8.5 English Non-fiction"
+  Description: "5.5x8.5 inch (139.7x215.9mm) horizontal layout for English non-fiction and textbooks"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 13.97     # 5.5 inches
+  Height: 21.59    # 8.5 inches
+  MarginTop: 1.59
+  MarginBottom: 1.59
+  MarginLeft: 1.59  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 1.0
+  MarginFooter: 1.0
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Serif"
+  EastAsia: "Noto Serif"
+  DefaultSize: 11
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 20
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "440"
+    SpaceAfter: "220"
+  H2:
+    Size: 15
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "320"
+    SpaceAfter: "160"
+  H3:
+    Size: 13
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "260"
+    SpaceAfter: "130"
+  H4:
+    Size: 12
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "200"
+    SpaceAfter: "100"
+  H5:
+    Size: 11
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "160"
+    SpaceAfter: "80"
+  H6:
+    Size: 11
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "120"
+    SpaceAfter: "60"
+  Paragraph:
+    Size: 11
+    Color: "1a1a1a"
+    LineSpacing: "330"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 11
+    Color: "1a1a1a"
+    LeftIndent: "720"
+    HangingIndent: "360"
+    SpaceBefore: "40"
+    SpaceAfter: "40"
+  CodeBlock:
+    Size: 8
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "250"
+    SpaceBefore: "150"
+    SpaceAfter: "150"
+    BorderSpace: 4
+  Quote:
+    Size: 11
+    Color: "555555"
+    Italic: true
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "720"
+    SpaceBefore: "150"
+    SpaceAfter: "150"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/5x8-en.yaml
+++ b/csharp-version/config/presets/5x8-en.yaml
@@ -1,0 +1,120 @@
+# 5x8 inch English compact non-fiction preset (127.0x203.2mm)
+# Suitable for: compact non-fiction, essays, short books
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "5x8 English Compact Non-fiction"
+  Description: "5x8 inch (127.0x203.2mm) horizontal layout for compact English books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 12.70     # 5 inches
+  Height: 20.32    # 8 inches
+  MarginTop: 1.27
+  MarginBottom: 1.27
+  MarginLeft: 1.27  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 0.8
+  MarginFooter: 0.8
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Serif"
+  EastAsia: "Noto Serif"
+  DefaultSize: 10
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 20
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "400"
+    SpaceAfter: "200"
+  H2:
+    Size: 14
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "300"
+    SpaceAfter: "150"
+  H3:
+    Size: 12
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "240"
+    SpaceAfter: "120"
+  H4:
+    Size: 11
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "180"
+    SpaceAfter: "90"
+  H5:
+    Size: 10
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "140"
+    SpaceAfter: "70"
+  H6:
+    Size: 10
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "100"
+    SpaceAfter: "50"
+  Paragraph:
+    Size: 10
+    Color: "1a1a1a"
+    LineSpacing: "320"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 10
+    Color: "1a1a1a"
+    LeftIndent: "640"
+    HangingIndent: "320"
+    SpaceBefore: "40"
+    SpaceAfter: "40"
+  CodeBlock:
+    Size: 8
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "240"
+    SpaceBefore: "140"
+    SpaceAfter: "140"
+    BorderSpace: 4
+  Quote:
+    Size: 10
+    Color: "555555"
+    Italic: true
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "640"
+    SpaceBefore: "140"
+    SpaceAfter: "140"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/6x9-en.yaml
+++ b/csharp-version/config/presets/6x9-en.yaml
@@ -1,0 +1,120 @@
+# 6x9 inch English non-fiction preset (152.4x228.6mm)
+# Suitable for: non-fiction, tech, business books
+# Inner margin (MarginLeft) assumes ~300-500 pages; increase for thicker books
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "6x9 English Non-fiction"
+  Description: "6x9 inch (152.4x228.6mm) horizontal layout for English non-fiction books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 15.24     # 6 inches
+  Height: 22.86    # 9 inches
+  MarginTop: 1.91
+  MarginBottom: 1.91
+  MarginLeft: 1.59  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 1.0
+  MarginFooter: 1.0
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Serif"
+  EastAsia: "Noto Serif"
+  DefaultSize: 11
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 22
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "480"
+    SpaceAfter: "240"
+  H2:
+    Size: 16
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "360"
+    SpaceAfter: "180"
+  H3:
+    Size: 13
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "280"
+    SpaceAfter: "140"
+  H4:
+    Size: 12
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "200"
+    SpaceAfter: "100"
+  H5:
+    Size: 11
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "160"
+    SpaceAfter: "80"
+  H6:
+    Size: 11
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "120"
+    SpaceAfter: "60"
+  Paragraph:
+    Size: 11
+    Color: "1a1a1a"
+    LineSpacing: "340"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 11
+    Color: "1a1a1a"
+    LeftIndent: "720"
+    HangingIndent: "360"
+    SpaceBefore: "40"
+    SpaceAfter: "40"
+  CodeBlock:
+    Size: 9
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "260"
+    SpaceBefore: "160"
+    SpaceAfter: "160"
+    BorderSpace: 4
+  Quote:
+    Size: 11
+    Color: "555555"
+    Italic: true
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "720"
+    SpaceBefore: "160"
+    SpaceAfter: "160"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/7x10-en.yaml
+++ b/csharp-version/config/presets/7x10-en.yaml
@@ -1,0 +1,120 @@
+# 7x10 inch English textbook/reference preset (177.8x254.0mm)
+# Suitable for: textbooks, reference books, workbooks
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "7x10 English Textbook"
+  Description: "7x10 inch (177.8x254.0mm) horizontal layout for English textbooks and reference books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 17.78     # 7 inches
+  Height: 25.40    # 10 inches
+  MarginTop: 1.91
+  MarginBottom: 1.91
+  MarginLeft: 1.91  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 1.0
+  MarginFooter: 1.0
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Serif"
+  EastAsia: "Noto Serif"
+  DefaultSize: 11
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 3
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 24
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "560"
+    SpaceAfter: "280"
+  H2:
+    Size: 18
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "400"
+    SpaceAfter: "200"
+  H3:
+    Size: 14
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "300"
+    SpaceAfter: "150"
+  H4:
+    Size: 12
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "220"
+    SpaceAfter: "110"
+  H5:
+    Size: 11
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "180"
+    SpaceAfter: "90"
+  H6:
+    Size: 11
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "140"
+    SpaceAfter: "70"
+  Paragraph:
+    Size: 11
+    Color: "1a1a1a"
+    LineSpacing: "340"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 11
+    Color: "1a1a1a"
+    LeftIndent: "720"
+    HangingIndent: "360"
+    SpaceBefore: "60"
+    SpaceAfter: "60"
+  CodeBlock:
+    Size: 9
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "270"
+    SpaceBefore: "160"
+    SpaceAfter: "160"
+    BorderSpace: 4
+  Quote:
+    Size: 11
+    Color: "555555"
+    Italic: true
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "720"
+    SpaceBefore: "160"
+    SpaceAfter: "160"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/a5-ja.yaml
+++ b/csharp-version/config/presets/a5-ja.yaml
@@ -1,0 +1,120 @@
+# A5 Japanese non-fiction preset (148x210mm)
+# Suitable for: tech books, business books, how-to guides
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "A5 Japanese Non-fiction"
+  Description: "A5 (148x210mm) horizontal layout for Japanese non-fiction books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 14.8
+  Height: 21.0
+  MarginTop: 1.9
+  MarginBottom: 1.9
+  MarginLeft: 1.59  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 1.0
+  MarginFooter: 1.0
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Sans"
+  EastAsia: "Noto Sans CJK JP"
+  DefaultSize: 9
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 18
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "400"
+    SpaceAfter: "200"
+  H2:
+    Size: 14
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "300"
+    SpaceAfter: "150"
+  H3:
+    Size: 11
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "240"
+    SpaceAfter: "120"
+  H4:
+    Size: 10
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "180"
+    SpaceAfter: "90"
+  H5:
+    Size: 9
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "140"
+    SpaceAfter: "70"
+  H6:
+    Size: 9
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "100"
+    SpaceAfter: "50"
+  Paragraph:
+    Size: 9
+    Color: "1a1a1a"
+    LineSpacing: "310"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 9
+    Color: "1a1a1a"
+    LeftIndent: "640"
+    HangingIndent: "320"
+    SpaceBefore: "40"
+    SpaceAfter: "40"
+  CodeBlock:
+    Size: 7
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "230"
+    SpaceBefore: "120"
+    SpaceAfter: "120"
+    BorderSpace: 4
+  Quote:
+    Size: 9
+    Color: "555555"
+    Italic: false
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "640"
+    SpaceBefore: "120"
+    SpaceAfter: "120"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/b5-ja.yaml
+++ b/csharp-version/config/presets/b5-ja.yaml
@@ -1,0 +1,120 @@
+# B5 Japanese textbook/reference preset (182x257mm)
+# Suitable for: textbooks, reference books, academic publications
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "B5 Japanese Textbook"
+  Description: "B5 (182x257mm) horizontal layout for Japanese textbooks and reference books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 18.2
+  Height: 25.7
+  MarginTop: 2.0
+  MarginBottom: 2.0
+  MarginLeft: 1.91  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 1.0
+  MarginFooter: 1.0
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Sans"
+  EastAsia: "Noto Sans CJK JP"
+  DefaultSize: 10
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 3
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 22
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "500"
+    SpaceAfter: "250"
+  H2:
+    Size: 16
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "360"
+    SpaceAfter: "180"
+  H3:
+    Size: 13
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "280"
+    SpaceAfter: "140"
+  H4:
+    Size: 11
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "200"
+    SpaceAfter: "100"
+  H5:
+    Size: 10
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "160"
+    SpaceAfter: "80"
+  H6:
+    Size: 10
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "120"
+    SpaceAfter: "60"
+  Paragraph:
+    Size: 10
+    Color: "1a1a1a"
+    LineSpacing: "320"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 10
+    Color: "1a1a1a"
+    LeftIndent: "720"
+    HangingIndent: "360"
+    SpaceBefore: "50"
+    SpaceAfter: "50"
+  CodeBlock:
+    Size: 8
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "250"
+    SpaceBefore: "140"
+    SpaceAfter: "140"
+    BorderSpace: 4
+  Quote:
+    Size: 10
+    Color: "555555"
+    Italic: false
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "720"
+    SpaceBefore: "140"
+    SpaceAfter: "140"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/b6-ja-vertical.yaml
+++ b/csharp-version/config/presets/b6-ja-vertical.yaml
@@ -1,0 +1,121 @@
+# B6 Japanese vertical text preset (128x182mm, tategaki)
+# Suitable for: novels, fiction, literary essays
+# Width/Height are specified in landscape orientation (Width=182mm, Height=128mm)
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "B6 Japanese Vertical Novel"
+  Description: "B6 (128x182mm) vertical layout for Japanese novels and fiction"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Vertical"
+
+PageLayout:
+  Width: 18.2   # physical height of B6 (182mm) — landscape orientation for vertical text
+  Height: 12.8  # physical width of B6 (128mm)
+  MarginTop: 1.5
+  MarginBottom: 1.5
+  MarginLeft: 1.27  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 0.8
+  MarginFooter: 0.8
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Serif"
+  EastAsia: "Noto Serif CJK JP"
+  DefaultSize: 9
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 18
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "360"
+    SpaceAfter: "180"
+  H2:
+    Size: 14
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "280"
+    SpaceAfter: "140"
+  H3:
+    Size: 11
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "220"
+    SpaceAfter: "110"
+  H4:
+    Size: 10
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "160"
+    SpaceAfter: "80"
+  H5:
+    Size: 9
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "120"
+    SpaceAfter: "60"
+  H6:
+    Size: 9
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "100"
+    SpaceAfter: "50"
+  Paragraph:
+    Size: 9
+    Color: "1a1a1a"
+    LineSpacing: "300"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 9
+    Color: "1a1a1a"
+    LeftIndent: "580"
+    HangingIndent: "290"
+    SpaceBefore: "30"
+    SpaceAfter: "30"
+  CodeBlock:
+    Size: 7
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "220"
+    SpaceBefore: "100"
+    SpaceAfter: "100"
+    BorderSpace: 4
+  Quote:
+    Size: 9
+    Color: "555555"
+    Italic: false
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "580"
+    SpaceBefore: "100"
+    SpaceAfter: "100"
+  Image:
+    MaxWidthPercent: 80
+    Alignment: "center"

--- a/csharp-version/config/presets/b6-ja.yaml
+++ b/csharp-version/config/presets/b6-ja.yaml
@@ -1,0 +1,120 @@
+# B6 Japanese non-fiction preset (128x182mm)
+# Suitable for: general non-fiction, essays, practical guides
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "B6 Japanese Non-fiction"
+  Description: "B6 (128x182mm) horizontal layout for Japanese non-fiction books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Horizontal"
+
+PageLayout:
+  Width: 12.8
+  Height: 18.2
+  MarginTop: 1.5
+  MarginBottom: 1.5
+  MarginLeft: 1.27  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 0.8
+  MarginFooter: 0.8
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Sans"
+  EastAsia: "Noto Sans CJK JP"
+  DefaultSize: 9
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 16
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "360"
+    SpaceAfter: "180"
+  H2:
+    Size: 13
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "280"
+    SpaceAfter: "140"
+  H3:
+    Size: 11
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "220"
+    SpaceAfter: "110"
+  H4:
+    Size: 10
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "160"
+    SpaceAfter: "80"
+  H5:
+    Size: 9
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "120"
+    SpaceAfter: "60"
+  H6:
+    Size: 9
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "100"
+    SpaceAfter: "50"
+  Paragraph:
+    Size: 9
+    Color: "1a1a1a"
+    LineSpacing: "300"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 9
+    Color: "1a1a1a"
+    LeftIndent: "580"
+    HangingIndent: "290"
+    SpaceBefore: "30"
+    SpaceAfter: "30"
+  CodeBlock:
+    Size: 7
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "220"
+    SpaceBefore: "100"
+    SpaceAfter: "100"
+    BorderSpace: 4
+  Quote:
+    Size: 9
+    Color: "555555"
+    Italic: false
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "580"
+    SpaceBefore: "100"
+    SpaceAfter: "100"
+  Image:
+    MaxWidthPercent: 90
+    Alignment: "center"

--- a/csharp-version/config/presets/shinsho-ja-vertical.yaml
+++ b/csharp-version/config/presets/shinsho-ja-vertical.yaml
@@ -1,0 +1,121 @@
+# Shinsho Japanese vertical text preset (103x182mm, tategaki)
+# Suitable for: compact vertical books, pocket-sized publications
+# Width/Height are specified in landscape orientation (Width=182mm, Height=103mm)
+# Inner margin (MarginLeft) assumes ~300-500 pages; adjust for page count
+SchemaVersion: "2.0"
+
+Metadata:
+  Name: "Shinsho Japanese Vertical"
+  Description: "Shinsho (103x182mm) vertical layout for compact Japanese books"
+  Author: "md2docx"
+  Version: "1.0.0"
+
+TextDirection: "Vertical"
+
+PageLayout:
+  Width: 18.2   # physical height of Shinsho (182mm) — landscape orientation for vertical text
+  Height: 10.3  # physical width of Shinsho (103mm)
+  MarginTop: 1.2
+  MarginBottom: 1.2
+  MarginLeft: 1.27  # inner (binding) margin
+  MarginRight: 0.64 # outer margin
+  MarginHeader: 0.7
+  MarginFooter: 0.7
+  MirrorMargins: true
+
+Fonts:
+  Ascii: "Noto Serif"
+  EastAsia: "Noto Serif CJK JP"
+  DefaultSize: 8
+
+TitlePage:
+  Enabled: false
+  PageBreakAfter: true
+
+TableOfContents:
+  Enabled: true
+  Depth: 2
+  PageBreakAfter: true
+
+Styles:
+  H1:
+    Size: 16
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    PageBreakBefore: true
+    SpaceBefore: "320"
+    SpaceAfter: "160"
+  H2:
+    Size: 12
+    Bold: true
+    Color: "1a1a1a"
+    ShowBorder: false
+    SpaceBefore: "240"
+    SpaceAfter: "120"
+  H3:
+    Size: 10
+    Bold: true
+    Color: "333333"
+    ShowBorder: false
+    SpaceBefore: "180"
+    SpaceAfter: "90"
+  H4:
+    Size: 9
+    Bold: true
+    Color: "444444"
+    ShowBorder: false
+    SpaceBefore: "140"
+    SpaceAfter: "70"
+  H5:
+    Size: 8
+    Bold: true
+    Color: "555555"
+    ShowBorder: false
+    SpaceBefore: "100"
+    SpaceAfter: "50"
+  H6:
+    Size: 8
+    Bold: false
+    Color: "666666"
+    ShowBorder: false
+    SpaceBefore: "80"
+    SpaceAfter: "40"
+  Paragraph:
+    Size: 8
+    Color: "1a1a1a"
+    LineSpacing: "280"
+    FirstLineIndent: "0"
+    LeftIndent: "0"
+  List:
+    Size: 8
+    Color: "1a1a1a"
+    LeftIndent: "520"
+    HangingIndent: "260"
+    SpaceBefore: "30"
+    SpaceAfter: "30"
+  CodeBlock:
+    Size: 6
+    Color: "333333"
+    BackgroundColor: "f5f5f5"
+    BorderColor: "cccccc"
+    MonospaceFontAscii: "Consolas"
+    MonospaceFontEastAsia: "Noto Sans Mono CJK JP"
+    LineSpacing: "200"
+    SpaceBefore: "80"
+    SpaceAfter: "80"
+    BorderSpace: 4
+  Quote:
+    Size: 8
+    Color: "555555"
+    Italic: false
+    ShowBorder: true
+    BorderColor: "888888"
+    BorderSize: 16
+    BorderSpace: 0
+    LeftIndent: "520"
+    SpaceBefore: "80"
+    SpaceAfter: "80"
+  Image:
+    MaxWidthPercent: 75
+    Alignment: "center"


### PR DESCRIPTION
## Summary

Add 9 standard book trim size preset YAML files for printed book production workflows.

Closes #46

## New Presets

### English formats
- **`6x9-en.yaml`** — 6×9 inch (152.4×228.6mm) English non-fiction
- **`5x8-en.yaml`** — 5×8 inch (127.0×203.2mm) English compact non-fiction
- **`5.5x8.5-en.yaml`** — 5.5×8.5 inch (139.7×215.9mm) English non-fiction / textbooks
- **`7x10-en.yaml`** — 7×10 inch (177.8×254.0mm) English textbooks / reference

### Japanese horizontal formats
- **`a5-ja.yaml`** — A5 (148×210mm) Japanese non-fiction
- **`b6-ja.yaml`** — B6 (128×182mm) Japanese general non-fiction
- **`b5-ja.yaml`** — B5 (182×257mm) Japanese textbooks / reference

### Japanese vertical (tategaki) formats
- **`b6-ja-vertical.yaml`** — B6 (128×182mm) Japanese vertical novels / fiction
- **`shinsho-ja-vertical.yaml`** — Shinsho (103×182mm) Japanese vertical compact books

## Design Decisions

- All presets use `MirrorMargins: true` for professional binding margins
- Naming convention: `{trim-size}-{language}[-{variant}]`
- No platform-specific (KDP, etc.) references — general-purpose presets
- Vertical presets store Width > Height (landscape orientation) as required for tategaki rendering
- English presets use Noto Serif; Japanese horizontal uses Noto Sans CJK JP; Japanese vertical uses Noto Serif CJK JP
- Font sizes and spacing scaled to each page size for readability

## Dependencies

- Requires #44 (MirrorMargins schema support) — already merged via #47
- Requires #45 (PageLayout Width/Height applied to DOCX output) — already merged via #47

## Test Plan

- [x] 235 tests pass (`dotnet test` green)
- [x] All 9 YAML files validated with `yaml.safe_load`
- [x] Width/Height cm values verified against standard trim sizes
- [x] Vertical presets confirmed Width > Height
- [x] No KDP or platform-specific references in any file
- [x] All comments in English