### PR TITLE
feat: add WordWrap option for CodeBlock to prevent overflow in narrow print areas

### DIFF
--- a/csharp-version/config/presets/a5-ja.yaml
+++ b/csharp-version/config/presets/a5-ja.yaml
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "120"
     SpaceAfter: "120"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 9
     Color: "555555"

--- a/csharp-version/src/MarkdownToDocx.Core/Models/CodeBlockStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/CodeBlockStyle.cs
@@ -55,4 +55,10 @@ public sealed record CodeBlockStyle
     /// Applied to all four sides of the code block border.
     /// </summary>
     public uint BorderSpace { get; init; } = 4;
+
+    /// <summary>
+    /// When true, enables word wrap for code block paragraphs.
+    /// Prevents long lines from overflowing narrow print areas (e.g., KDP paperback).
+    /// </summary>
+    public bool WordWrap { get; init; } = false;
 }

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -812,6 +812,12 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
             LineRule = LineSpacingRuleValues.Auto
         });
 
+        // Word wrap
+        if (style.WordWrap)
+        {
+            props.AppendChild(new WordWrap());
+        }
+
         return props;
     }
 

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -284,6 +284,13 @@ public sealed record CodeBlockStyleConfig
     /// Reducing this value makes single-line code blocks appear more compact.
     /// </summary>
     public uint BorderSpace { get; init; } = 4;
+
+    /// <summary>
+    /// When true, enables word wrap for code block paragraphs.
+    /// Prevents long lines from overflowing narrow print areas (e.g., KDP paperback).
+    /// Defaults to false to preserve standard code block rendering.
+    /// </summary>
+    public bool WordWrap { get; init; } = false;
 }
 
 /// <summary>

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -100,7 +100,8 @@ public sealed class StyleApplicator : IStyleApplicator
             LineSpacing = config.CodeBlock.LineSpacing,
             SpaceBefore = config.CodeBlock.SpaceBefore,
             SpaceAfter = config.CodeBlock.SpaceAfter,
-            BorderSpace = config.CodeBlock.BorderSpace
+            BorderSpace = config.CodeBlock.BorderSpace,
+            WordWrap = config.CodeBlock.WordWrap
         };
     }
 

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -540,6 +540,52 @@ public class OpenXmlDocumentBuilderTests : IDisposable
     }
 
     [Fact]
+    public void AddCodeBlock_WithWordWrapEnabled_ShouldAddWordWrapElement()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultCodeBlockStyle() with { WordWrap = true };
+
+        // Act
+        builder.AddCodeBlock("var x = 42;", null, style);
+        builder.Save();
+
+        // Assert: paragraph properties must contain a WordWrap element
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        paragraph.ParagraphProperties!
+            .GetFirstChild<WordWrap>()
+            .Should().NotBeNull("WordWrap element should be present when WordWrap = true");
+    }
+
+    [Fact]
+    public void AddCodeBlock_WithWordWrapDisabled_ShouldNotAddWordWrapElement()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultCodeBlockStyle() with { WordWrap = false };
+
+        // Act
+        builder.AddCodeBlock("var x = 42;", null, style);
+        builder.Save();
+
+        // Assert: paragraph properties must NOT contain a WordWrap element
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        paragraph.ParagraphProperties!
+            .GetFirstChild<WordWrap>()
+            .Should().BeNull("WordWrap element should not be present when WordWrap = false");
+    }
+
+    [Fact]
     public void AddQuote_WithNullRuns_ShouldThrowArgumentNullException()
     {
         // Arrange

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
@@ -283,6 +283,38 @@ public class StyleApplicatorTests
     }
 
     [Fact]
+    public void ApplyCodeBlockStyle_WithWordWrapTrue_ShouldMapWordWrap()
+    {
+        // Arrange
+        var config = new StyleConfiguration
+        {
+            CodeBlock = new CodeBlockStyleConfig { Size = 9, Color = "000000", WordWrap = true }
+        };
+
+        // Act
+        var style = _applicator.ApplyCodeBlockStyle(config);
+
+        // Assert
+        style.WordWrap.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ApplyCodeBlockStyle_WithDefaultWordWrap_ShouldBeFalse()
+    {
+        // Arrange
+        var config = new StyleConfiguration
+        {
+            CodeBlock = new CodeBlockStyleConfig { Size = 9, Color = "000000" }
+        };
+
+        // Act
+        var style = _applicator.ApplyCodeBlockStyle(config);
+
+        // Assert
+        style.WordWrap.Should().BeFalse();
+    }
+
+    [Fact]
     public void ApplyQuoteStyle_ShouldReturnCorrectStyle()
     {
         // Act


### PR DESCRIPTION
## Summary

- Add `WordWrap` boolean property to `CodeBlockStyleConfig` (YAML) and `CodeBlockStyle` (core model)
- When `WordWrap: true`, a `<w:wordWrap/>` element is appended to the code block paragraph properties, enabling Word to wrap long lines within the printable width
- Default is `false` — no change to existing behaviour
- Enable `WordWrap: true` in the `a5-ja.yaml` preset to resolve KDP A5 paperback overflow

## Motivation

KDP paperback (A5, 148×210mm) has a printable width of ~122.5mm (~82 chars at 7pt Noto Sans Mono). Lines longer than that overflow the page margin and are flagged as errors by KDP's print-on-demand previewer.

## Changes

| File | Change |
|------|--------|
| `CodeBlockStyle.cs` | Add `WordWrap` property (default `false`) |
| `StyleConfiguration.cs` | Add `WordWrap` to `CodeBlockStyleConfig` |
| `StyleApplicator.cs` | Pass `WordWrap` through mapping |
| `OpenXmlDocumentBuilder.cs` | Append `<w:wordWrap/>` when `WordWrap = true` |
| `a5-ja.yaml` | Set `WordWrap: true` |
| `OpenXmlDocumentBuilderTests.cs` | 2 new tests (enabled / disabled) |
| `StyleApplicatorTests.cs` | 2 new tests (true / false mapping) |

## Test plan

- [x] All 239 unit tests pass
- [x] `WordWrap = true` → `<w:wordWrap/>` present in paragraph properties
- [x] `WordWrap = false` (default) → no `<w:wordWrap/>` element
- [x] `StyleApplicator` correctly maps `true` and `false` from config to model

Closes #49