### PR TITLE
fix: increase outer margin to 1.27cm and add LayoutValidator for overflow detection

### DIFF
--- a/csharp-version/config/presets/5.5x8.5-en.yaml
+++ b/csharp-version/config/presets/5.5x8.5-en.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 1.59
   MarginBottom: 1.59
   MarginLeft: 1.59  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 1.0
   MarginFooter: 1.0
   MirrorMargins: true
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "150"
     SpaceAfter: "150"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 11
     Color: "555555"

--- a/csharp-version/config/presets/5x8-en.yaml
+++ b/csharp-version/config/presets/5x8-en.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 1.27
   MarginBottom: 1.27
   MarginLeft: 1.27  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 0.8
   MarginFooter: 0.8
   MirrorMargins: true
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "140"
     SpaceAfter: "140"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 10
     Color: "555555"

--- a/csharp-version/config/presets/6x9-en.yaml
+++ b/csharp-version/config/presets/6x9-en.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 1.91
   MarginBottom: 1.91
   MarginLeft: 1.59  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 1.0
   MarginFooter: 1.0
   MirrorMargins: true
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "160"
     SpaceAfter: "160"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 11
     Color: "555555"

--- a/csharp-version/config/presets/7x10-en.yaml
+++ b/csharp-version/config/presets/7x10-en.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 1.91
   MarginBottom: 1.91
   MarginLeft: 1.91  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 1.0
   MarginFooter: 1.0
   MirrorMargins: true
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "160"
     SpaceAfter: "160"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 11
     Color: "555555"

--- a/csharp-version/config/presets/a5-ja.yaml
+++ b/csharp-version/config/presets/a5-ja.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 1.9
   MarginBottom: 1.9
   MarginLeft: 1.59  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 1.0
   MarginFooter: 1.0
   MirrorMargins: true

--- a/csharp-version/config/presets/b5-ja.yaml
+++ b/csharp-version/config/presets/b5-ja.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 2.0
   MarginBottom: 2.0
   MarginLeft: 1.91  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 1.0
   MarginFooter: 1.0
   MirrorMargins: true
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "140"
     SpaceAfter: "140"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 10
     Color: "555555"

--- a/csharp-version/config/presets/b6-ja-vertical.yaml
+++ b/csharp-version/config/presets/b6-ja-vertical.yaml
@@ -18,7 +18,7 @@ PageLayout:
   MarginTop: 1.5
   MarginBottom: 1.5
   MarginLeft: 1.27  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 0.8
   MarginFooter: 0.8
   MirrorMargins: true
@@ -105,6 +105,7 @@ Styles:
     SpaceBefore: "100"
     SpaceAfter: "100"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 9
     Color: "555555"

--- a/csharp-version/config/presets/b6-ja.yaml
+++ b/csharp-version/config/presets/b6-ja.yaml
@@ -17,7 +17,7 @@ PageLayout:
   MarginTop: 1.5
   MarginBottom: 1.5
   MarginLeft: 1.27  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 0.8
   MarginFooter: 0.8
   MirrorMargins: true
@@ -104,6 +104,7 @@ Styles:
     SpaceBefore: "100"
     SpaceAfter: "100"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 9
     Color: "555555"

--- a/csharp-version/config/presets/shinsho-ja-vertical.yaml
+++ b/csharp-version/config/presets/shinsho-ja-vertical.yaml
@@ -18,7 +18,7 @@ PageLayout:
   MarginTop: 1.2
   MarginBottom: 1.2
   MarginLeft: 1.27  # inner (binding) margin
-  MarginRight: 0.64 # outer margin
+  MarginRight: 1.27 # outer margin
   MarginHeader: 0.7
   MarginFooter: 0.7
   MirrorMargins: true
@@ -105,6 +105,7 @@ Styles:
     SpaceBefore: "80"
     SpaceAfter: "80"
     BorderSpace: 4
+    WordWrap: true
   Quote:
     Size: 8
     Color: "555555"

--- a/csharp-version/tests/MarkdownToDocx.Tests/LayoutValidator.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/LayoutValidator.cs
@@ -1,0 +1,257 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace MarkdownToDocx.Tests;
+
+/// <summary>
+/// Validates OOXML layout properties to detect margin overflow risks.
+/// Operates on structural metadata only — no rendering engine required.
+/// </summary>
+public static class LayoutValidator
+{
+    private const double TwipsPerCm = 567.0;
+
+    /// <summary>Minimum acceptable outer margin in twips (10mm = 1.0cm).</summary>
+    public const uint MinOuterMarginTwips = 567; // 10mm
+
+    /// <summary>
+    /// Maximum estimated characters per line before flagging overflow risk.
+    /// Based on: printable width / (fontSize * 0.6 scaling factor for monospace).
+    /// Callers should compute this dynamically; this constant is used as a fallback.
+    /// </summary>
+    public const int DefaultMaxCharsPerLine = 80;
+
+    /// <summary>
+    /// Reads page geometry from a WordprocessingDocument and returns a summary.
+    /// </summary>
+    public static PageGeometry GetPageGeometry(WordprocessingDocument doc)
+    {
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var sectionProps = body.Elements<SectionProperties>().LastOrDefault()
+            ?? throw new InvalidOperationException("No SectionProperties found in document.");
+
+        var pageSize = sectionProps.Elements<PageSize>().FirstOrDefault()
+            ?? throw new InvalidOperationException("No PageSize found in SectionProperties.");
+
+        var pageMargin = sectionProps.Elements<PageMargin>().FirstOrDefault()
+            ?? throw new InvalidOperationException("No PageMargin found in SectionProperties.");
+
+        var settingsPart = doc.MainDocumentPart.DocumentSettingsPart;
+        bool mirrorMargins = settingsPart?.Settings
+            .Elements<MirrorMargins>().Any() == true;
+
+        uint widthTwips = pageSize.Width?.Value
+            ?? throw new InvalidOperationException("PageSize.Width is null.");
+        uint heightTwips = pageSize.Height?.Value
+            ?? throw new InvalidOperationException("PageSize.Height is null.");
+        uint leftTwips = pageMargin.Left?.Value
+            ?? throw new InvalidOperationException("PageMargin.Left is null.");
+        uint rightTwips = pageMargin.Right?.Value
+            ?? throw new InvalidOperationException("PageMargin.Right is null.");
+
+        uint printableWidthTwips = widthTwips - leftTwips - rightTwips;
+
+        return new PageGeometry(
+            WidthTwips: widthTwips,
+            HeightTwips: heightTwips,
+            LeftMarginTwips: leftTwips,
+            RightMarginTwips: rightTwips,
+            PrintableWidthTwips: printableWidthTwips,
+            MirrorMargins: mirrorMargins);
+    }
+
+    /// <summary>
+    /// Checks that both left and right margins meet the minimum threshold.
+    /// With MirrorMargins, the outer margin is min(left, right).
+    /// </summary>
+    public static MarginCheckResult CheckMinimumMargins(PageGeometry geometry)
+    {
+        uint outerMarginTwips = geometry.MirrorMargins
+            ? Math.Min(geometry.LeftMarginTwips, geometry.RightMarginTwips)
+            : Math.Min(geometry.LeftMarginTwips, geometry.RightMarginTwips);
+
+        bool passes = outerMarginTwips >= MinOuterMarginTwips;
+
+        return new MarginCheckResult(
+            Passes: passes,
+            OuterMarginTwips: outerMarginTwips,
+            OuterMarginMm: outerMarginTwips / TwipsPerCm * 10.0,
+            MinRequiredTwips: MinOuterMarginTwips);
+    }
+
+    /// <summary>
+    /// Checks code block paragraphs for lines that may exceed printable width.
+    /// Uses character count × font size estimation (monospace assumption).
+    /// Returns all violations found.
+    /// </summary>
+    public static IReadOnlyList<CodeBlockLineViolation> CheckCodeBlockLineWidths(
+        WordprocessingDocument doc,
+        PageGeometry geometry)
+    {
+        var violations = new List<CodeBlockLineViolation>();
+        var body = doc.MainDocumentPart!.Document.Body!;
+
+        // Code block paragraphs are identified by having ParagraphBorders on all 4 sides
+        var codeBlockParagraphs = body.Descendants<Paragraph>()
+            .Where(IsCodeBlockParagraph)
+            .ToList();
+
+        foreach (var para in codeBlockParagraphs)
+        {
+            // Retrieve font size from first run (in half-points → convert to pt)
+            double fontSizePt = GetCodeBlockFontSizePt(para);
+
+            // Estimate max chars that fit: printable_width_mm / (fontSize_pt * 0.21mm/pt * charWidthRatio)
+            // Monospace char width ≈ fontSize × 0.6 (empirical for Consolas/Noto Sans Mono)
+            double printableWidthMm = geometry.PrintableWidthTwips / TwipsPerCm * 10.0;
+            int estimatedMaxChars = fontSizePt > 0
+                ? (int)(printableWidthMm / (fontSizePt * 0.21 * 0.6))
+                : DefaultMaxCharsPerLine;
+
+            // Reconstruct lines from Text elements (separated by Break elements)
+            var run = para.Elements<Run>().FirstOrDefault();
+            if (run is null) continue;
+
+            var lineTexts = ReconstructLines(run);
+            for (int i = 0; i < lineTexts.Count; i++)
+            {
+                if (lineTexts[i].Length > estimatedMaxChars)
+                {
+                    violations.Add(new CodeBlockLineViolation(
+                        LineIndex: i,
+                        CharCount: lineTexts[i].Length,
+                        EstimatedMaxChars: estimatedMaxChars,
+                        FontSizePt: fontSizePt));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    /// <summary>
+    /// Checks that all code block paragraphs have WordWrap enabled.
+    /// </summary>
+    public static WordWrapCheckResult CheckWordWrapOnCodeBlocks(WordprocessingDocument doc)
+    {
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var codeBlockParagraphs = body.Descendants<Paragraph>()
+            .Where(IsCodeBlockParagraph)
+            .ToList();
+
+        int total = codeBlockParagraphs.Count;
+        int missing = codeBlockParagraphs
+            .Count(p => p.ParagraphProperties?.GetFirstChild<WordWrap>() is null);
+
+        return new WordWrapCheckResult(
+            TotalCodeBlocks: total,
+            MissingWordWrap: missing,
+            Passes: missing == 0);
+    }
+
+    /// <summary>
+    /// Checks that no paragraph's left indentation exceeds half the printable width.
+    /// </summary>
+    public static IReadOnlyList<IndentViolation> CheckParagraphIndentation(
+        WordprocessingDocument doc,
+        PageGeometry geometry)
+    {
+        var violations = new List<IndentViolation>();
+        var body = doc.MainDocumentPart!.Document.Body!;
+
+        foreach (var para in body.Descendants<Paragraph>())
+        {
+            var indent = para.ParagraphProperties?.Elements<Indentation>().FirstOrDefault();
+            if (indent?.Left?.Value is not null
+                && int.TryParse(indent.Left.Value, out int leftIndentTwips)
+                && leftIndentTwips > (int)(geometry.PrintableWidthTwips / 2))
+            {
+                violations.Add(new IndentViolation(
+                    LeftIndentTwips: leftIndentTwips,
+                    PrintableWidthTwips: (int)geometry.PrintableWidthTwips));
+            }
+        }
+
+        return violations;
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private static bool IsCodeBlockParagraph(Paragraph para)
+    {
+        var borders = para.ParagraphProperties?.ParagraphBorders;
+        if (borders is null) return false;
+
+        return borders.GetFirstChild<TopBorder>() is not null
+            && borders.GetFirstChild<BottomBorder>() is not null
+            && borders.GetFirstChild<LeftBorder>() is not null
+            && borders.GetFirstChild<RightBorder>() is not null;
+    }
+
+    private static double GetCodeBlockFontSizePt(Paragraph para)
+    {
+        var fontSize = para.Elements<Run>().FirstOrDefault()
+            ?.RunProperties
+            ?.FontSize;
+
+        if (fontSize?.Val?.Value is string val && int.TryParse(val, out int halfPoints))
+            return halfPoints / 2.0;
+
+        return 9.0; // fallback: 9pt default
+    }
+
+    private static List<string> ReconstructLines(Run run)
+    {
+        var lines = new List<string>();
+        var currentLine = new System.Text.StringBuilder();
+
+        foreach (var child in run.ChildElements)
+        {
+            if (child is Text text)
+            {
+                currentLine.Append(text.Text);
+            }
+            else if (child is Break)
+            {
+                lines.Add(currentLine.ToString());
+                currentLine.Clear();
+            }
+        }
+
+        if (currentLine.Length > 0 || lines.Count == 0)
+            lines.Add(currentLine.ToString());
+
+        return lines;
+    }
+}
+
+// ── Result types ──────────────────────────────────────────────────────────────
+
+public record PageGeometry(
+    uint WidthTwips,
+    uint HeightTwips,
+    uint LeftMarginTwips,
+    uint RightMarginTwips,
+    uint PrintableWidthTwips,
+    bool MirrorMargins);
+
+public record MarginCheckResult(
+    bool Passes,
+    uint OuterMarginTwips,
+    double OuterMarginMm,
+    uint MinRequiredTwips);
+
+public record CodeBlockLineViolation(
+    int LineIndex,
+    int CharCount,
+    int EstimatedMaxChars,
+    double FontSizePt);
+
+public record WordWrapCheckResult(
+    int TotalCodeBlocks,
+    int MissingWordWrap,
+    bool Passes);
+
+public record IndentViolation(
+    int LeftIndentTwips,
+    int PrintableWidthTwips);

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/LayoutValidatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/LayoutValidatorTests.cs
@@ -1,0 +1,252 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
+using MarkdownToDocx.Core.Interfaces;
+using MarkdownToDocx.Core.Models;
+using MarkdownToDocx.Core.OpenXml;
+using MarkdownToDocx.Core.TextDirection;
+using MarkdownToDocx.Styling.Models;
+using MarkdownToDocx.Styling.TextDirection;
+using Xunit;
+using W = DocumentFormat.OpenXml.Wordprocessing;
+
+namespace MarkdownToDocx.Tests.Unit;
+
+/// <summary>
+/// Tests for the LayoutValidator — structural overflow risk detection.
+/// </summary>
+public class LayoutValidatorTests : IDisposable
+{
+    private readonly MemoryStream _stream = new();
+
+    public void Dispose() => _stream.Dispose();
+
+    // ── PageGeometry ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetPageGeometry_ShouldReturnCorrectDimensions()
+    {
+        // Arrange: A5 horizontal, margins 1.59cm left, 1.27cm right
+        var provider = BuildProvider(14.8, 21.0, marginLeft: 1.59, marginRight: 1.27);
+        using var builder = new OpenXmlDocumentBuilder(_stream, provider);
+        builder.AddParagraph(ToRuns("test"), DefaultParagraphStyle());
+        builder.Save();
+
+        // Act
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var geometry = LayoutValidator.GetPageGeometry(doc);
+
+        // Assert
+        geometry.LeftMarginTwips.Should().Be(Round(1.59));
+        geometry.RightMarginTwips.Should().Be(Round(1.27));
+        geometry.PrintableWidthTwips.Should().Be(Round(14.8) - Round(1.59) - Round(1.27));
+    }
+
+    // ── MarginCheck ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckMinimumMargins_WithAdequateMargins_ShouldPass()
+    {
+        // Arrange: outer margin = 1.27cm = 720 twips (> 567 minimum)
+        var geometry = BuildGeometry(leftTwips: 900, rightTwips: 720, mirrorMargins: true);
+
+        // Act
+        var result = LayoutValidator.CheckMinimumMargins(geometry);
+
+        // Assert
+        result.Passes.Should().BeTrue();
+        result.OuterMarginMm.Should().BeApproximately(12.7, 0.5);
+    }
+
+    [Fact]
+    public void CheckMinimumMargins_WithTooNarrowMargin_ShouldFail()
+    {
+        // Arrange: outer margin = 0.64cm = 363 twips (< 567 minimum = 10mm)
+        var geometry = BuildGeometry(leftTwips: 900, rightTwips: 363, mirrorMargins: true);
+
+        // Act
+        var result = LayoutValidator.CheckMinimumMargins(geometry);
+
+        // Assert
+        result.Passes.Should().BeFalse();
+        result.OuterMarginMm.Should().BeApproximately(6.4, 0.5);
+    }
+
+    // ── WordWrap check ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckWordWrapOnCodeBlocks_WhenEnabled_ShouldPass()
+    {
+        // Arrange
+        var provider = BuildProvider(14.8, 21.0);
+        using var builder = new OpenXmlDocumentBuilder(_stream, provider);
+        builder.AddCodeBlock("var x = 42;", null, DefaultCodeBlockStyle(wordWrap: true));
+        builder.Save();
+
+        // Act
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var result = LayoutValidator.CheckWordWrapOnCodeBlocks(doc);
+
+        // Assert
+        result.TotalCodeBlocks.Should().Be(1);
+        result.Passes.Should().BeTrue();
+        result.MissingWordWrap.Should().Be(0);
+    }
+
+    [Fact]
+    public void CheckWordWrapOnCodeBlocks_WhenDisabled_ShouldFail()
+    {
+        // Arrange
+        var provider = BuildProvider(14.8, 21.0);
+        using var builder = new OpenXmlDocumentBuilder(_stream, provider);
+        builder.AddCodeBlock("var x = 42;", null, DefaultCodeBlockStyle(wordWrap: false));
+        builder.Save();
+
+        // Act
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var result = LayoutValidator.CheckWordWrapOnCodeBlocks(doc);
+
+        // Assert
+        result.TotalCodeBlocks.Should().Be(1);
+        result.Passes.Should().BeFalse();
+        result.MissingWordWrap.Should().Be(1);
+    }
+
+    // ── CodeBlock line length ─────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckCodeBlockLineWidths_ShortLines_ShouldHaveNoViolations()
+    {
+        // Arrange: A5 printable width ~119mm, 7pt → max ~134 chars, 10-char line is fine
+        var provider = BuildProvider(14.8, 21.0, marginLeft: 1.59, marginRight: 1.27);
+        using var builder = new OpenXmlDocumentBuilder(_stream, provider);
+        builder.AddCodeBlock("short line", null, DefaultCodeBlockStyle(wordWrap: true));
+        builder.Save();
+
+        // Act
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var geometry = LayoutValidator.GetPageGeometry(doc);
+        var violations = LayoutValidator.CheckCodeBlockLineWidths(doc, geometry);
+
+        // Assert
+        violations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckCodeBlockLineWidths_VeryLongLine_ShouldReportViolation()
+    {
+        // Arrange: 200-char line will exceed any reasonable A5 width estimate
+        var longLine = new string('x', 200);
+        var provider = BuildProvider(14.8, 21.0, marginLeft: 1.59, marginRight: 1.27);
+        using var builder = new OpenXmlDocumentBuilder(_stream, provider);
+        builder.AddCodeBlock(longLine, null, DefaultCodeBlockStyle(wordWrap: false));
+        builder.Save();
+
+        // Act
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var geometry = LayoutValidator.GetPageGeometry(doc);
+        var violations = LayoutValidator.CheckCodeBlockLineWidths(doc, geometry);
+
+        // Assert
+        violations.Should().NotBeEmpty();
+        violations[0].CharCount.Should().Be(200);
+    }
+
+    // ── Indentation check ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckParagraphIndentation_NormalIndent_ShouldHaveNoViolations()
+    {
+        // Arrange: standard list indent (640 twips) is well within printable width
+        var provider = BuildProvider(14.8, 21.0, marginLeft: 1.59, marginRight: 1.27);
+        using var builder = new OpenXmlDocumentBuilder(_stream, provider);
+        var listStyle = DefaultListStyle();
+        builder.AddList(
+            new[] { new MarkdownToDocx.Core.Models.ListItem { Text = "item" } },
+            false,
+            listStyle);
+        builder.Save();
+
+        // Act
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var geometry = LayoutValidator.GetPageGeometry(doc);
+        var violations = LayoutValidator.CheckParagraphIndentation(doc, geometry);
+
+        // Assert
+        violations.Should().BeEmpty();
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static uint Round(double cm) => (uint)Math.Round(cm * 567.0);
+
+    private static PageGeometry BuildGeometry(
+        uint leftTwips, uint rightTwips, bool mirrorMargins = false)
+    {
+        uint width = 8390; // A5 approx
+        return new PageGeometry(
+            WidthTwips: width,
+            HeightTwips: 11900,
+            LeftMarginTwips: leftTwips,
+            RightMarginTwips: rightTwips,
+            PrintableWidthTwips: width - leftTwips - rightTwips,
+            MirrorMargins: mirrorMargins);
+    }
+
+    private static ITextDirectionProvider BuildProvider(
+        double widthCm, double heightCm,
+        double marginLeft = 1.59, double marginRight = 1.27)
+    {
+        var layout = new PageLayoutConfig
+        {
+            Width = widthCm,
+            Height = heightCm,
+            MarginTop = 1.9,
+            MarginBottom = 1.9,
+            MarginLeft = marginLeft,
+            MarginRight = marginRight,
+            MirrorMargins = true
+        };
+        return new ConfigurableTextDirectionProvider(new HorizontalTextProvider(), layout);
+    }
+
+    private static InlineRun[] ToRuns(string text)
+        => new[] { new InlineRun { Text = text } };
+
+    private static ParagraphStyle DefaultParagraphStyle() => new()
+    {
+        FontSize = 18, Color = "000000",
+        LineSpacing = "240", FirstLineIndent = "0", LeftIndent = "0"
+    };
+
+    private static CodeBlockStyle DefaultCodeBlockStyle(bool wordWrap = true) => new()
+    {
+        FontSize = 14, // 7pt in half-points
+        Color = "333333",
+        BackgroundColor = "f5f5f5",
+        BorderColor = "cccccc",
+        MonospaceFontAscii = "Consolas",
+        MonospaceFontEastAsia = "Noto Sans Mono CJK JP",
+        SpaceBefore = "120",
+        SpaceAfter = "120",
+        LineSpacing = "230",
+        BorderSpace = 4,
+        WordWrap = wordWrap
+    };
+
+    private static ListStyle DefaultListStyle() => new()
+    {
+        FontSize = 18,
+        Color = "000000",
+        LeftIndent = "640",
+        HangingIndent = "320",
+        SpaceBefore = "40",
+        SpaceAfter = "40"
+    };
+}


### PR DESCRIPTION
## Summary

- All 9 book trim presets had `MarginRight: 0.64cm` (KDP minimum = 6.4mm). With `MirrorMargins: true`, this becomes the **left margin on even pages**, causing heading borders and code block borders to appear flush with the page edge
- Increase `MarginRight: 0.64 → 1.27` (12.7mm = 0.5 inch) across all 9 presets
- Add `WordWrap: true` to `CodeBlock` in the 8 presets that were missing it
- Add `LayoutValidator` — a structural OOXML checker that detects overflow risks without a rendering engine

## Changes

| Area | Change |
|------|--------|
| 9 preset YAMLs | `MarginRight: 0.64 → 1.27` |
| 8 preset YAMLs | `WordWrap: true` added to `CodeBlock` |
| `LayoutValidator.cs` | New static class with 4 checks |
| `LayoutValidatorTests.cs` | 8 new unit tests |

## LayoutValidator checks

| Method | What it detects |
|--------|----------------|
| `CheckMinimumMargins` | Outer margin >= 10mm (567 twips) |
| `CheckCodeBlockLineWidths` | Char count × font size estimation for monospace overflow |
| `CheckWordWrapOnCodeBlocks` | `<w:wordWrap/>` element present on all code blocks |
| `CheckParagraphIndentation` | Left indent < half printable width |

## Limitations (documented in code)

- Actual pixel-level overflow requires a rendering engine
- Font metric accuracy depends on monospace assumption (Consolas / Noto Sans Mono)

## Test plan

- [x] 247 unit tests pass (239 existing + 8 new)
- [x] `CheckMinimumMargins` correctly flags 0.64cm as failing (< 10mm threshold)
- [x] `CheckMinimumMargins` passes for 1.27cm
- [x] `CheckWordWrapOnCodeBlocks` detects missing `WordWrap` element
- [x] 200-char line triggers `CheckCodeBlockLineWidths` violation
- [x] Normal list indent (640 twips) passes `CheckParagraphIndentation`

Closes #51