### PR TITLE
fix: prevent paragraph border overflow on narrow outer margins with MirrorMargins

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -803,6 +803,16 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
         // Background shading
         props.AppendChild(CreateBackgroundShading(style.BackgroundColor));
 
+        // Indentation: left/right borders use w:space (points) as external gap toward the margin.
+        // Without indentation the border extends space points outside the text area into the margin,
+        // causing visible overflow on narrow outer margins (e.g. MirrorMargins with 1.27 cm outer).
+        // Adding indent equal to BorderSpace * 20 twips anchors the border at the margin boundary.
+        if (style.BorderSpace > 0)
+        {
+            string indentTwips = (style.BorderSpace * 20).ToString();
+            props.AppendChild(new Indentation { Left = indentTwips, Right = indentTwips });
+        }
+
         // Spacing
         props.AppendChild(new SpacingBetweenLines
         {
@@ -901,8 +911,14 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
             props.AppendChild(CreateBackgroundShading(style.BackgroundColor));
         }
 
-        // Indentation
-        props.AppendChild(new Indentation { Left = style.LeftIndent });
+        // Indentation: right padding border extends PaddingSpace points outside the right text
+        // boundary into the margin. Add matching right indent to anchor the border at the margin.
+        var indentation = new Indentation { Left = style.LeftIndent };
+        if (hasPadding && style.PaddingSpace > 0)
+        {
+            indentation.Right = (style.PaddingSpace * 20).ToString();
+        }
+        props.AppendChild(indentation);
 
         // Spacing
         props.AppendChild(new SpacingBetweenLines

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -586,6 +586,110 @@ public class OpenXmlDocumentBuilderTests : IDisposable
     }
 
     [Fact]
+    public void AddCodeBlock_WithBorderSpace_ShouldAddMatchingIndentation()
+    {
+        // Arrange: BorderSpace = 4 pt → indent must be 4 * 20 = 80 twips on both sides
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultCodeBlockStyle() with { BorderSpace = 4 };
+
+        // Act
+        builder.AddCodeBlock("var x = 42;", null, style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var indent = paragraph.ParagraphProperties!.GetFirstChild<Indentation>();
+        indent.Should().NotBeNull("Indentation must be added when BorderSpace > 0");
+        indent!.Left?.Value.Should().Be("80");
+        indent!.Right?.Value.Should().Be("80");
+    }
+
+    [Fact]
+    public void AddCodeBlock_WithZeroBorderSpace_ShouldNotAddIndentation()
+    {
+        // Arrange: default BorderSpace = 0 → no indentation added
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultCodeBlockStyle() with { BorderSpace = 0 };
+
+        // Act
+        builder.AddCodeBlock("var x = 42;", null, style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        paragraph.ParagraphProperties!
+            .GetFirstChild<Indentation>()
+            .Should().BeNull("No Indentation should be added when BorderSpace = 0");
+    }
+
+    [Fact]
+    public void AddQuote_WithPaddingSpaceAndBackground_ShouldAddRightIndentation()
+    {
+        // Arrange: PaddingSpace = 4 pt → right indent must be 4 * 20 = 80 twips
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultQuoteStyle() with
+        {
+            BackgroundColor = "f0f0f0",
+            PaddingSpace = 4,
+            LeftIndent = "560"
+        };
+
+        // Act
+        builder.AddQuote(ToRuns("test"), style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var indent = paragraph.ParagraphProperties!.GetFirstChild<Indentation>();
+        indent.Should().NotBeNull();
+        indent!.Left?.Value.Should().Be("560");
+        indent!.Right?.Value.Should().Be("80", "right indent = PaddingSpace * 20 twips prevents right border overflow");
+    }
+
+    [Fact]
+    public void AddQuote_WithoutPaddingSpace_ShouldNotAddRightIndentation()
+    {
+        // Arrange: PaddingSpace = 0 or no background → no right indent
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultQuoteStyle() with
+        {
+            BackgroundColor = null,
+            PaddingSpace = 0,
+            LeftIndent = "720"
+        };
+
+        // Act
+        builder.AddQuote(ToRuns("test"), style);
+        builder.Save();
+
+        // Assert
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var indent = paragraph.ParagraphProperties!.GetFirstChild<Indentation>();
+        indent.Should().NotBeNull();
+        indent!.Right.Should().BeNull("no right indentation when PaddingSpace = 0");
+    }
+
+    [Fact]
     public void AddQuote_WithNullRuns_ShouldThrowArgumentNullException()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Fixes #53

OOXML `w:pBdr` `w:space` is an **external** gap: the border line is drawn `space` points outside the text area, toward the page margin. When a paragraph has no left/right indentation, the border extends into (or beyond) the margin — visually overflowing on narrow outer margins with `MirrorMargins: true`.

## Changes

- **CodeBlock**: Add `Indentation.Left = Right = BorderSpace * 20 twips` when `BorderSpace > 0`. This anchors the left/right borders at the margin boundary. Visual appearance is unchanged (border at margin, text `BorderSpace` pt inside).
- **Quote**: Add `Indentation.Right = PaddingSpace * 20 twips` when `PaddingSpace > 0` and `BackgroundColor` is set. This anchors the invisible right padding border at the right margin.

## Root Cause

```xml
<!-- Before: left border extends 80 twips (4pt) OUTSIDE the left margin -->
<w:pBdr>
  <w:left w:space="4" ... />   <!-- border = margin - 80 twips → OVERFLOW -->
</w:pBdr>
<!-- no <w:ind> -->

<!-- After: left border anchored at margin boundary -->
<w:pBdr>
  <w:left w:space="4" ... />   <!-- border = indent - space = margin + 80 - 80 = margin ✓ -->
</w:pBdr>
<w:ind w:left="80" w:right="80" />
```

## Test Plan

- [x] 4 new unit tests covering CodeBlock `BorderSpace` (0 and 4 pt) and Quote `PaddingSpace` (with/without background)
- [x] All 251 tests pass
- [x] OOXML output verified: `<w:ind w:left="80" w:right="80"/>` present on code blocks with `BorderSpace: 4`