### PR TITLE
fix: add tblGrid and fixed layout to prevent table column overflow (#57)

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -937,15 +937,25 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
         ArgumentNullException.ThrowIfNull(tableData);
         ArgumentNullException.ThrowIfNull(style);
 
+        // Compute printable text area width in twips from page configuration.
+        // This is used for tblGrid column widths and tcW dxa values so Word
+        // honours the column widths even in autofit mode.
+        var pageConfig = _textDirection.GetPageConfiguration();
+        int textAreaTwips = (int)(uint)pageConfig.Width
+            - pageConfig.LeftMargin
+            - pageConfig.RightMargin
+            - pageConfig.GutterMargin;
+
         // Spacer paragraph before table
         AddTableSpacer(style.SpaceBefore);
 
         var table = _body.AppendChild(new Table());
-        table.AppendChild(CreateTableProperties(tableData.ColumnCount, style));
+        table.AppendChild(CreateTableProperties(style));
+        table.AppendChild(CreateTableGrid(tableData.ColumnCount, textAreaTwips));
 
         foreach (var row in tableData.Rows)
         {
-            table.AppendChild(CreateTableRow(row, tableData.ColumnCount, style));
+            table.AppendChild(CreateTableRow(row, tableData.ColumnCount, style, textAreaTwips));
         }
 
         // Spacer paragraph after table
@@ -966,19 +976,22 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     }
 
     /// <summary>
-    /// Creates TableProperties with percentage-based width (prevents margin overflow)
-    /// and border/padding configuration
+    /// Creates TableProperties with percentage-based width (overflow safety net) and
+    /// fixed layout so Word honours the tblGrid column widths.
     /// </summary>
-    private static TableProperties CreateTableProperties(int columnCount, CoreTableStyle style)
+    private static TableProperties CreateTableProperties(CoreTableStyle style)
     {
         var tableProps = new TableProperties();
 
-        // Use percentage width (5000 = 100% of text area) to prevent margin overflow
+        // tblW=5000pct acts as overflow safety net (100% of text area)
         tableProps.AppendChild(new TableWidth
         {
             Type = TableWidthUnitValues.Pct,
             Width = "5000"
         });
+
+        // Fixed layout: Word must honour tblGrid column widths, not autofit to content
+        tableProps.AppendChild(new TableLayout { Type = TableLayoutValues.Fixed });
 
         // Table borders: all sides + inside horizontal/vertical
         tableProps.AppendChild(new TableBorders(
@@ -1002,9 +1015,24 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     }
 
     /// <summary>
+    /// Creates a TableGrid element that defines equal-width columns so Word's fixed-layout
+    /// engine can distribute the text area width evenly across all columns.
+    /// </summary>
+    private static TableGrid CreateTableGrid(int columnCount, int textAreaTwips)
+    {
+        var grid = new TableGrid();
+        int colWidth = columnCount > 0 ? textAreaTwips / columnCount : textAreaTwips;
+        for (int i = 0; i < columnCount; i++)
+        {
+            grid.AppendChild(new GridColumn { Width = colWidth.ToString(CultureInfo.InvariantCulture) });
+        }
+        return grid;
+    }
+
+    /// <summary>
     /// Creates a TableRow element with cells
     /// </summary>
-    private TableRow CreateTableRow(TableRowData rowData, int columnCount, CoreTableStyle style)
+    private TableRow CreateTableRow(TableRowData rowData, int columnCount, CoreTableStyle style, int textAreaTwips)
     {
         var row = new TableRow();
 
@@ -1016,7 +1044,7 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
 
         foreach (var cell in rowData.Cells)
         {
-            row.AppendChild(CreateTableCell(cell, columnCount, rowData.IsHeader, style));
+            row.AppendChild(CreateTableCell(cell, columnCount, rowData.IsHeader, style, textAreaTwips));
         }
 
         return row;
@@ -1025,17 +1053,17 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     /// <summary>
     /// Creates a TableCell element with content
     /// </summary>
-    private TableCell CreateTableCell(TableCellData cellData, int columnCount, bool isHeader, CoreTableStyle style)
+    private TableCell CreateTableCell(TableCellData cellData, int columnCount, bool isHeader, CoreTableStyle style, int textAreaTwips)
     {
         var cell = new TableCell();
 
-        // Cell properties: equal column width in percentage
-        int colWidthPct = columnCount > 0 ? 5000 / columnCount : 5000;
+        // Cell width in dxa matches the tblGrid gridCol width so Word renders fixed columns
+        int colWidthDxa = columnCount > 0 ? textAreaTwips / columnCount : textAreaTwips;
         var cellProps = new TableCellProperties();
         cellProps.AppendChild(new TableCellWidth
         {
-            Type = TableWidthUnitValues.Pct,
-            Width = colWidthPct.ToString(CultureInfo.InvariantCulture)
+            Type = TableWidthUnitValues.Dxa,
+            Width = colWidthDxa.ToString(CultureInfo.InvariantCulture)
         });
 
         // Header background shading

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -2392,6 +2392,97 @@ public class OpenXmlDocumentBuilderTests : IDisposable
     }
 
     [Fact]
+    public void AddTable_ShouldHaveFixedTableLayout()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var builder = new OpenXmlDocumentBuilder(stream, _horizontalProvider);
+        var tableData = new TableData
+        {
+            ColumnCount = 2,
+            Rows = [new TableRowData { IsHeader = false, Cells = [new TableCellData { Runs = [new InlineRun { Text = "A" }] }, new TableCellData { Runs = [new InlineRun { Text = "B" }] }] }]
+        };
+
+        builder.AddTable(tableData, CreateDefaultTableStyle());
+        builder.Save();
+
+        // Assert: w:tblLayout has type="fixed"
+        stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var tblLayout = body.Descendants<DocumentFormat.OpenXml.Wordprocessing.Table>().First()
+            .GetFirstChild<TableProperties>()!
+            .GetFirstChild<TableLayout>();
+
+        tblLayout.Should().NotBeNull("table must use fixed layout to prevent autofit overflow");
+        tblLayout!.Type!.Value.Should().Be(TableLayoutValues.Fixed);
+    }
+
+    [Fact]
+    public void AddTable_ShouldHaveTableGridWithCorrectColumnCount()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var builder = new OpenXmlDocumentBuilder(stream, _horizontalProvider);
+        const int expectedColumns = 3;
+        var tableData = new TableData
+        {
+            ColumnCount = expectedColumns,
+            Rows = [new TableRowData { IsHeader = false, Cells = [
+                new TableCellData { Runs = [new InlineRun { Text = "A" }] },
+                new TableCellData { Runs = [new InlineRun { Text = "B" }] },
+                new TableCellData { Runs = [new InlineRun { Text = "C" }] }
+            ] }]
+        };
+
+        builder.AddTable(tableData, CreateDefaultTableStyle());
+        builder.Save();
+
+        // Assert: w:tblGrid contains 3 w:gridCol elements
+        stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var grid = body.Descendants<DocumentFormat.OpenXml.Wordprocessing.Table>().First()
+            .GetFirstChild<TableGrid>();
+
+        grid.Should().NotBeNull("tblGrid is required for fixed-layout column width enforcement");
+        grid!.Descendants<GridColumn>().Should().HaveCount(expectedColumns);
+    }
+
+    [Fact]
+    public void AddTable_CellWidth_ShouldUseDxaType()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var builder = new OpenXmlDocumentBuilder(stream, _horizontalProvider);
+        var tableData = new TableData
+        {
+            ColumnCount = 2,
+            Rows = [new TableRowData { IsHeader = false, Cells = [
+                new TableCellData { Runs = [new InlineRun { Text = "A" }] },
+                new TableCellData { Runs = [new InlineRun { Text = "B" }] }
+            ] }]
+        };
+
+        builder.AddTable(tableData, CreateDefaultTableStyle());
+        builder.Save();
+
+        // Assert: all w:tcW elements use type="dxa" (matches gridCol widths for fixed layout)
+        stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var cells = body.Descendants<TableCell>().ToList();
+        cells.Should().NotBeEmpty();
+        foreach (var cell in cells)
+        {
+            var tcWidth = cell.GetFirstChild<TableCellProperties>()!.GetFirstChild<TableCellWidth>();
+            tcWidth.Should().NotBeNull();
+            tcWidth!.Type!.Value.Should().Be(TableWidthUnitValues.Dxa,
+                "cell width must use dxa to match tblGrid gridCol widths in fixed-layout tables");
+        }
+    }
+
+    [Fact]
     public void AddTable_WithHeaderRow_ShouldApplyHeaderBackground()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- Add `w:tblGrid` with equal-width `gridCol` entries (`textAreaTwips / columnCount`) so Word's fixed-layout engine has column width anchors
- Add `w:tblLayout type="fixed"` to force Word to honour the gridCol widths instead of autofitting to content
- Change `w:tcW` from `type="pct"` to `type="dxa"` matching gridCol values (pct is ignored without tblGrid in autofit mode)
- Keep `tblW=5000pct` as an overflow safety net

## Root Cause

All tables generated by md2docx had `tblW=5000pct` but no `tblGrid` element. Without `tblGrid`, Word's autofit mode ignores `tcW type=pct` and expands each column to fit its content, which causes tables with wide cells (e.g. command tables in technical docs) to overflow the page margins.

## Test plan

- [x] `AddTable_ShouldHaveFixedTableLayout` — verifies `w:tblLayout type="fixed"` is present
- [x] `AddTable_ShouldHaveTableGridWithCorrectColumnCount` — verifies `w:tblGrid` has N `gridCol` entries
- [x] `AddTable_CellWidth_ShouldUseDxaType` — verifies `w:tcW type="dxa"` on all cells
- [x] Existing `AddTable_ShouldUsePercentageWidth` still passes (`tblW=5000pct` unchanged)
- [x] All 276 tests pass

Closes #57