### PR TITLE
feat: add WidthPercent to TableStyle for configurable table width

### DIFF
--- a/config/presets/default.yaml
+++ b/config/presets/default.yaml
@@ -120,3 +120,5 @@ Styles:
     BackgroundColor: "f8f9fa"
     SpaceBefore: "300"
     SpaceAfter: "300"
+  Table:
+    WidthPercent: 100   # 1-100: table width as % of printable area

--- a/config/presets/minimal.yaml
+++ b/config/presets/minimal.yaml
@@ -115,3 +115,5 @@ Styles:
     LeftIndent: "720"
     SpaceBefore: "240"
     SpaceAfter: "240"
+  Table:
+    WidthPercent: 100   # 1-100: table width as % of printable area

--- a/config/presets/technical.yaml
+++ b/config/presets/technical.yaml
@@ -120,3 +120,5 @@ Styles:
     BackgroundColor: "f0f4f8"
     SpaceBefore: "240"
     SpaceAfter: "240"
+  Table:
+    WidthPercent: 100   # 1-100: table width as % of printable area

--- a/csharp-version/src/MarkdownToDocx.Core/Models/TableStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/TableStyle.cs
@@ -69,4 +69,10 @@ public sealed record TableStyle
     /// Space after table in twips
     /// </summary>
     public string SpaceAfter { get; init; } = "160";
+
+    /// <summary>
+    /// Table width as a percentage of the printable text area (1-100).
+    /// Values below 100 leave horizontal space around the table.
+    /// </summary>
+    public int WidthPercent { get; init; } = 100;
 }

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -937,14 +937,14 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
         ArgumentNullException.ThrowIfNull(tableData);
         ArgumentNullException.ThrowIfNull(style);
 
-        // Compute printable text area width in twips from page configuration.
-        // This is used for tblGrid column widths and tcW dxa values so Word
-        // honours the column widths even in autofit mode.
+        // Compute printable text area width in twips from page configuration,
+        // then scale by WidthPercent so the table can be narrower than the full text area.
         var pageConfig = _textDirection.GetPageConfiguration();
-        int textAreaTwips = (int)(uint)pageConfig.Width
+        int fullTextAreaTwips = (int)(uint)pageConfig.Width
             - pageConfig.LeftMargin
             - pageConfig.RightMargin
             - pageConfig.GutterMargin;
+        int textAreaTwips = (int)(fullTextAreaTwips * style.WidthPercent / 100.0);
 
         // Spacer paragraph before table
         AddTableSpacer(style.SpaceBefore);
@@ -983,11 +983,13 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     {
         var tableProps = new TableProperties();
 
-        // tblW=5000pct acts as overflow safety net (100% of text area)
+        // tblW in pct units (5000 = 100%). Scaled by WidthPercent so the table
+        // can be narrower than the full text area (e.g. 90% → "4500").
+        int tblWidthPct = style.WidthPercent * 50; // 1% = 50 in OOXML pct units
         tableProps.AppendChild(new TableWidth
         {
             Type = TableWidthUnitValues.Pct,
-            Width = "5000"
+            Width = tblWidthPct.ToString(CultureInfo.InvariantCulture)
         });
 
         // Fixed layout: Word must honour tblGrid column widths, not autofit to content

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -449,6 +449,13 @@ public sealed record TableStyleConfig
     /// Spacing after table in twips (1/20 of a point)
     /// </summary>
     public string SpaceAfter { get; init; } = "160";
+
+    /// <summary>
+    /// Table width as a percentage of the printable text area (1-100).
+    /// Use values below 100 to leave horizontal breathing room around the table.
+    /// Default: 100 (full text-area width).
+    /// </summary>
+    public int WidthPercent { get; init; } = 100;
 }
 
 /// <summary>

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -149,7 +149,8 @@ public sealed class StyleApplicator : IStyleApplicator
             CellPaddingLeft = config.Table.CellPaddingLeft,
             CellPaddingRight = config.Table.CellPaddingRight,
             SpaceBefore = config.Table.SpaceBefore,
-            SpaceAfter = config.Table.SpaceAfter
+            SpaceAfter = config.Table.SpaceAfter,
+            WidthPercent = Math.Clamp(config.Table.WidthPercent, 1, 100)
         };
     }
 

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -2391,6 +2391,37 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         tblWidth.Width!.Value.Should().Be("5000");
     }
 
+    [Theory]
+    [InlineData(100, "5000")]
+    [InlineData(90, "4500")]
+    [InlineData(75, "3750")]
+    public void AddTable_WidthPercent_ShouldScaleTblW(int widthPercent, string expectedPct)
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var builder = new OpenXmlDocumentBuilder(stream, _horizontalProvider);
+        var tableData = new TableData
+        {
+            ColumnCount = 2,
+            Rows = [new TableRowData { IsHeader = false, Cells = [new TableCellData { Runs = [new InlineRun { Text = "A" }] }, new TableCellData { Runs = [new InlineRun { Text = "B" }] }] }]
+        };
+        var style = CreateDefaultTableStyle() with { WidthPercent = widthPercent };
+
+        builder.AddTable(tableData, style);
+        builder.Save();
+
+        // Assert: tblW uses correct pct value
+        stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var tblWidth = doc.MainDocumentPart!.Document.Body!
+            .Descendants<DocumentFormat.OpenXml.Wordprocessing.Table>().First()
+            .GetFirstChild<TableProperties>()!
+            .GetFirstChild<TableWidth>();
+
+        tblWidth!.Type!.Value.Should().Be(TableWidthUnitValues.Pct);
+        tblWidth.Width!.Value.Should().Be(expectedPct);
+    }
+
     [Fact]
     public void AddTable_ShouldHaveFixedTableLayout()
     {


### PR DESCRIPTION
## Summary

- Add `Table.WidthPercent` (1–100, default 100) to YAML configuration
- Tables narrower than 100% leave horizontal breathing room within the text area
- `tblW` pct value and `tblGrid` column widths are both scaled proportionally

## Usage

```yaml
Styles:
  Table:
    WidthPercent: 90   # table uses 90% of the printable area width
```

## Test plan

- [x] `AddTable_WidthPercent_ShouldScaleTblW` — Theory with 100/90/75%
- [x] All 279 tests pass