### PR TITLE
fix: change default table WidthPercent from 100 to 90

### DIFF
--- a/config/presets/default.yaml
+++ b/config/presets/default.yaml
@@ -121,4 +121,4 @@ Styles:
     SpaceBefore: "300"
     SpaceAfter: "300"
   Table:
-    WidthPercent: 100   # 1-100: table width as % of printable area
+    WidthPercent: 90   # 1-100: table width as % of printable area

--- a/config/presets/minimal.yaml
+++ b/config/presets/minimal.yaml
@@ -116,4 +116,4 @@ Styles:
     SpaceBefore: "240"
     SpaceAfter: "240"
   Table:
-    WidthPercent: 100   # 1-100: table width as % of printable area
+    WidthPercent: 90   # 1-100: table width as % of printable area

--- a/config/presets/technical.yaml
+++ b/config/presets/technical.yaml
@@ -121,4 +121,4 @@ Styles:
     SpaceBefore: "240"
     SpaceAfter: "240"
   Table:
-    WidthPercent: 100   # 1-100: table width as % of printable area
+    WidthPercent: 90   # 1-100: table width as % of printable area

--- a/csharp-version/src/MarkdownToDocx.Core/Models/TableStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/TableStyle.cs
@@ -74,5 +74,5 @@ public sealed record TableStyle
     /// Table width as a percentage of the printable text area (1-100).
     /// Values below 100 leave horizontal space around the table.
     /// </summary>
-    public int WidthPercent { get; init; } = 100;
+    public int WidthPercent { get; init; } = 90;
 }

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -455,7 +455,7 @@ public sealed record TableStyleConfig
     /// Use values below 100 to leave horizontal breathing room around the table.
     /// Default: 100 (full text-area width).
     /// </summary>
-    public int WidthPercent { get; init; } = 100;
+    public int WidthPercent { get; init; } = 90;
 }
 
 /// <summary>

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -2378,7 +2378,7 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         builder.AddTable(tableData, CreateDefaultTableStyle());
         builder.Save();
 
-        // Assert: w:tblW has type="pct" and w="5000"
+        // Assert: w:tblW has type="pct" and w="4500" (default WidthPercent=90 → 90*50=4500)
         stream.Position = 0;
         using var doc = WordprocessingDocument.Open(stream, false);
         var body = doc.MainDocumentPart!.Document.Body!;
@@ -2388,7 +2388,7 @@ public class OpenXmlDocumentBuilderTests : IDisposable
 
         tblWidth.Should().NotBeNull();
         tblWidth!.Type!.Value.Should().Be(TableWidthUnitValues.Pct);
-        tblWidth.Width!.Value.Should().Be("5000");
+        tblWidth.Width!.Value.Should().Be("4500");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Change default `WidthPercent` from 100 → 90 in both `TableStyle` and `TableStyleConfig`
- Tables were filling the text area edge-to-edge by default; 90% gives visual breathing room without any configuration
- Users who want full-width tables can still set `Table.WidthPercent: 100` in YAML

## Test plan

- [x] Updated `AddTable_ShouldUsePercentageWidth` expectation: `"5000"` → `"4500"`
- [x] All 279 tests pass