### PR TITLE
fix: force box-mode rendering for left-only paragraph borders (#61)

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -156,6 +156,21 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
             paragraphBorders.AppendChild(border);
         }
 
+        // When only "left" is specified, Word anchors the border at the paragraph indent (flush
+        // with text) instead of at the page content edge. Adding Nil borders for the unspecified
+        // sides forces Word into box-mode rendering, which anchors the left border at position 0
+        // so that LeftIndent creates a visible gap between the border line and the text.
+        var specifiedPositions = new HashSet<string>(positions);
+        if (specifiedPositions.Contains("left"))
+        {
+            if (!specifiedPositions.Contains("top"))
+                paragraphBorders.AppendChild(new TopBorder { Val = BorderValues.Nil });
+            if (!specifiedPositions.Contains("bottom"))
+                paragraphBorders.AppendChild(new BottomBorder { Val = BorderValues.Nil });
+            if (!specifiedPositions.Contains("right"))
+                paragraphBorders.AppendChild(new RightBorder { Val = BorderValues.Nil });
+        }
+
         return paragraphBorders;
     }
 

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -2229,6 +2229,103 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         indentation!.Left!.Value.Should().Be("400");
     }
 
+    [Fact]
+    public void AddHeading_WithLeftBorderOnly_ShouldAddNilBordersForBoxMode()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            ShowBorder = true,
+            BorderPosition = "left",
+            BorderColor = "0066cc",
+            BorderSize = 24,
+            BorderSpace = 8,
+            LeftIndent = "200"
+        };
+
+        // Act
+        builder.AddHeading(3, "Section", style);
+        builder.Save();
+
+        // Assert: left border is Single; top/bottom/right are Nil to force box-mode rendering
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var borders = paragraph.ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<LeftBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<TopBorder>()!.Val!.Value.Should().Be(BorderValues.Nil);
+        borders.GetFirstChild<BottomBorder>()!.Val!.Value.Should().Be(BorderValues.Nil);
+        borders.GetFirstChild<RightBorder>()!.Val!.Value.Should().Be(BorderValues.Nil);
+    }
+
+    [Fact]
+    public void AddHeading_WithAllFourBorders_ShouldNotAddNilBorders()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            ShowBorder = true,
+            BorderPosition = "left,top,right,bottom",
+            BorderColor = "0066cc",
+            BorderSize = 12,
+            BorderSpace = 4
+        };
+
+        // Act
+        builder.AddHeading(2, "Section", style);
+        builder.Save();
+
+        // Assert: all four borders are Single, none are Nil
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var borders = paragraph.ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<LeftBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<TopBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<BottomBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<RightBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+    }
+
+    [Fact]
+    public void AddHeading_WithBottomBorderOnly_ShouldNotAddNilBorders()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            ShowBorder = true,
+            BorderPosition = "bottom",
+            BorderColor = "cccccc",
+            BorderSize = 8,
+            BorderSpace = 2
+        };
+
+        // Act
+        builder.AddHeading(2, "Section", style);
+        builder.Save();
+
+        // Assert: only bottom border exists, no Nil borders added (box-mode only applies to left)
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var borders = paragraph.ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<BottomBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<LeftBorder>().Should().BeNull();
+        borders.GetFirstChild<TopBorder>().Should().BeNull();
+        borders.GetFirstChild<RightBorder>().Should().BeNull();
+    }
+
     public void Dispose()
     {
         _stream?.Dispose();


### PR DESCRIPTION
## Problem

When `BorderPosition: "left"` is used on headings, Word anchors the left border at the paragraph's indent position (flush with the text). The `BorderSpace` attribute controls vertical extent only, not horizontal gap. As a result, the border line touches the text with zero visible gap regardless of `LeftIndent`.

## Root Cause

Word uses two rendering modes for `w:pBdr`:
- **Single-side mode** (only `left` defined): border anchored at `ind.left` — flush with text
- **Box mode** (all four sides defined): border anchored at page content edge (position 0) — `ind.left` becomes the visible gap

Quote blocks work correctly because they define all four sides, triggering box mode.

## Fix

In `CreateBordersFromPositions()`, when only `left` is specified, add `BorderValues.Nil` borders for `top`, `bottom`, and `right`. This forces Word into box-mode rendering, making `LeftIndent` produce a visible gap between the border line and the text.

## Tests

Three new unit tests added:
- `AddHeading_WithLeftBorderOnly_ShouldAddNilBordersForBoxMode`
- `AddHeading_WithAllFourBorders_ShouldNotAddNilBorders`
- `AddHeading_WithBottomBorderOnly_ShouldNotAddNilBorders`

## Result

279 → 282 tests, all passing.

Closes #61