### PR TITLE
feat: add native styling support for fenced div blocks (:::classname)

### DIFF
--- a/csharp-version/src/MarkdownToDocx.CLI/Helpers.cs
+++ b/csharp-version/src/MarkdownToDocx.CLI/Helpers.cs
@@ -1,3 +1,4 @@
+using Markdig.Extensions.CustomContainers;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -174,6 +175,51 @@ public static class Helpers
     /// </summary>
     public static TableData GetTableData(Table table) =>
         MarkdownToDocx.Core.Markdown.TableExtractor.Extract(table);
+
+    /// <summary>
+    /// Extracts structured child blocks from a Markdig CustomContainer (:::classname ... :::).
+    /// Supports paragraphs, headings, tables, and lists within the div.
+    /// Unrecognized child block types are silently skipped.
+    /// </summary>
+    public static FencedDivContent GetFencedDivContent(CustomContainer container)
+    {
+        var blocks = new List<FencedDivBlock>();
+
+        foreach (var child in container)
+        {
+            switch (child)
+            {
+                case ParagraphBlock paragraph:
+                    var runs = new List<InlineRun>();
+                    if (paragraph.Inline != null)
+                        ExtractInlineRuns(paragraph.Inline, runs, bold: false, italic: false);
+                    if (runs.Count > 0)
+                        blocks.Add(new FencedDivParagraph { Runs = runs });
+                    break;
+
+                case HeadingBlock heading:
+                    var headingText = GetBlockText(heading);
+                    if (!string.IsNullOrEmpty(headingText))
+                        blocks.Add(new FencedDivHeading { Level = heading.Level, Text = headingText });
+                    break;
+
+                case Table table:
+                    blocks.Add(new FencedDivTable { Data = GetTableData(table) });
+                    break;
+
+                case ListBlock list:
+                    var items = GetListItems(list).ToList();
+                    if (items.Count > 0)
+                    {
+                        var startNumber = int.TryParse(list.OrderedStart, out var parsed) ? parsed : 1;
+                        blocks.Add(new FencedDivList { Items = items, IsOrdered = list.IsOrdered, StartNumber = startNumber });
+                    }
+                    break;
+            }
+        }
+
+        return new FencedDivContent { Blocks = blocks };
+    }
 
     private static void ExtractInlineRuns(Inline? inline, List<InlineRun> runs, bool bold, bool italic)
     {

--- a/csharp-version/src/MarkdownToDocx.CLI/Program.cs
+++ b/csharp-version/src/MarkdownToDocx.CLI/Program.cs
@@ -1,3 +1,4 @@
+using Markdig.Extensions.CustomContainers;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using MarkdownToDocx.CLI;
@@ -133,6 +134,15 @@ try
                     var tableData = Helpers.GetTableData(tableBlock);
                     var tableStyle = styleApplicator.ApplyTableStyle(config.Styles);
                     builder.AddTable(tableData, tableStyle);
+                    break;
+
+                case CustomContainer container:
+                    var className = container.Info ?? string.Empty;
+                    if (!config.Styles.FencedDivs.TryGetValue(className, out var divConfig))
+                        divConfig = new MarkdownToDocx.Styling.Models.FencedDivClassConfig();
+                    var divStyle = styleApplicator.ApplyFencedDivStyle(divConfig, config.Styles);
+                    var divContent = Helpers.GetFencedDivContent(container);
+                    builder.AddFencedDiv(divContent, divStyle);
                     break;
 
                 case ThematicBreakBlock:

--- a/csharp-version/src/MarkdownToDocx.Core/Interfaces/IDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Interfaces/IDocumentBuilder.cs
@@ -76,6 +76,14 @@ public interface IDocumentBuilder : IDisposable
     void AddTable(TableData tableData, TableStyle style);
 
     /// <summary>
+    /// Adds a fenced div block to the document.
+    /// Renders child blocks with background shading and optional top/bottom separator borders.
+    /// </summary>
+    /// <param name="content">Structured child blocks extracted from the fenced div</param>
+    /// <param name="style">Fenced div visual style</param>
+    void AddFencedDiv(FencedDivContent content, FencedDivStyle style);
+
+    /// <summary>
     /// Adds a thematic break (horizontal rule) to the document
     /// </summary>
     void AddThematicBreak();

--- a/csharp-version/src/MarkdownToDocx.Core/Models/FencedDivContent.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/FencedDivContent.cs
@@ -1,0 +1,77 @@
+namespace MarkdownToDocx.Core.Models;
+
+/// <summary>
+/// Structured content extracted from a fenced div block.
+/// Contains an ordered list of typed child blocks ready for rendering.
+/// </summary>
+public sealed class FencedDivContent
+{
+    /// <summary>
+    /// Ordered sequence of child blocks within the fenced div.
+    /// </summary>
+    public IReadOnlyList<FencedDivBlock> Blocks { get; init; } = [];
+}
+
+/// <summary>
+/// Base type for all child blocks within a fenced div.
+/// </summary>
+public abstract class FencedDivBlock { }
+
+/// <summary>
+/// A paragraph (with inline formatting) inside a fenced div.
+/// </summary>
+public sealed class FencedDivParagraph : FencedDivBlock
+{
+    /// <summary>
+    /// Structured inline runs with bold/italic/code formatting.
+    /// </summary>
+    public IReadOnlyList<InlineRun> Runs { get; init; } = [];
+}
+
+/// <summary>
+/// A heading inside a fenced div.
+/// </summary>
+public sealed class FencedDivHeading : FencedDivBlock
+{
+    /// <summary>
+    /// Heading level (1–6).
+    /// </summary>
+    public int Level { get; init; }
+
+    /// <summary>
+    /// Plain text content of the heading.
+    /// </summary>
+    public string Text { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// A table inside a fenced div.
+/// </summary>
+public sealed class FencedDivTable : FencedDivBlock
+{
+    /// <summary>
+    /// Structured table data with rows, cells, and alignment.
+    /// </summary>
+    public TableData Data { get; init; } = new();
+}
+
+/// <summary>
+/// A list (ordered or unordered) inside a fenced div.
+/// </summary>
+public sealed class FencedDivList : FencedDivBlock
+{
+    /// <summary>
+    /// List items.
+    /// </summary>
+    public IReadOnlyList<ListItem> Items { get; init; } = [];
+
+    /// <summary>
+    /// True for numbered list, false for bullet list.
+    /// </summary>
+    public bool IsOrdered { get; init; }
+
+    /// <summary>
+    /// First number for ordered lists.
+    /// </summary>
+    public int StartNumber { get; init; } = 1;
+}

--- a/csharp-version/src/MarkdownToDocx.Core/Models/FencedDivStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/FencedDivStyle.cs
@@ -1,0 +1,79 @@
+namespace MarkdownToDocx.Core.Models;
+
+/// <summary>
+/// Styling configuration for a fenced div block (:::classname ... :::).
+/// Background color is applied to all child paragraphs.
+/// Top/bottom separator lines appear on the first and last paragraph-like elements.
+/// </summary>
+public sealed record FencedDivStyle
+{
+    /// <summary>
+    /// Background fill color in hex (e.g., "F2F2F2"). Empty = no shading.
+    /// </summary>
+    public string BackgroundColor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Top separator line color in hex (e.g., "AAAAAA"). Empty = no top border.
+    /// </summary>
+    public string BorderTopColor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Top separator line thickness in eighths of a point (default: 4 = 0.5pt).
+    /// </summary>
+    public uint BorderTopSize { get; init; } = 4;
+
+    /// <summary>
+    /// Bottom separator line color in hex (e.g., "AAAAAA"). Empty = no bottom border.
+    /// </summary>
+    public string BorderBottomColor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Bottom separator line thickness in eighths of a point (default: 4 = 0.5pt).
+    /// </summary>
+    public uint BorderBottomSize { get; init; } = 4;
+
+    /// <summary>
+    /// Space between separator line and text in points (default: 0).
+    /// </summary>
+    public uint BorderSpace { get; init; } = 0;
+
+    /// <summary>
+    /// Spacing before the first block in the div in twips.
+    /// </summary>
+    public string SpaceBefore { get; init; } = "0";
+
+    /// <summary>
+    /// Spacing after the last block in the div in twips.
+    /// </summary>
+    public string SpaceAfter { get; init; } = "0";
+
+    /// <summary>
+    /// Left indent for div paragraphs in twips.
+    /// </summary>
+    public string LeftIndent { get; init; } = "0";
+
+    /// <summary>
+    /// Font size in half-points (inherited from paragraph style).
+    /// </summary>
+    public int FontSize { get; init; }
+
+    /// <summary>
+    /// Text color in hex (inherited from paragraph style).
+    /// </summary>
+    public string Color { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Line spacing in twips (inherited from paragraph style).
+    /// </summary>
+    public string LineSpacing { get; init; } = "360";
+
+    /// <summary>
+    /// Monospace font for inline code ASCII characters.
+    /// </summary>
+    public string InlineCodeFontAscii { get; init; } = "Courier New";
+
+    /// <summary>
+    /// Monospace font for inline code East Asian characters.
+    /// </summary>
+    public string InlineCodeFontEastAsia { get; init; } = "Noto Sans Mono CJK JP";
+}

--- a/csharp-version/src/MarkdownToDocx.Core/Models/TableStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/TableStyle.cs
@@ -75,4 +75,11 @@ public sealed record TableStyle
     /// Values below 100 leave horizontal space around the table.
     /// </summary>
     public int WidthPercent { get; init; } = 90;
+
+    /// <summary>
+    /// Background color applied to all body cells in hex (e.g., "F2F2F2").
+    /// When set (e.g., when the table is inside a fenced div), overrides the default
+    /// transparent body cell background. Null or empty means no shading.
+    /// </summary>
+    public string? BodyCellBackgroundColor { get; init; }
 }

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -1083,10 +1083,15 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
             Width = colWidthDxa.ToString(CultureInfo.InvariantCulture)
         });
 
-        // Header background shading
+        // Cell background shading: header always uses HeaderBackgroundColor;
+        // body cells use BodyCellBackgroundColor when set (e.g., inside a fenced div).
         if (isHeader)
         {
             cellProps.AppendChild(CreateBackgroundShading(style.HeaderBackgroundColor));
+        }
+        else if (!string.IsNullOrEmpty(style.BodyCellBackgroundColor))
+        {
+            cellProps.AppendChild(CreateBackgroundShading(style.BodyCellBackgroundColor));
         }
 
         cell.AppendChild(cellProps);
@@ -1136,6 +1141,234 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
         }
 
         return cell;
+    }
+
+    /// <inheritdoc/>
+    public void AddFencedDiv(FencedDivContent content, FencedDivStyle style)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(style);
+
+        var blocks = content.Blocks;
+        if (blocks.Count == 0) return;
+
+        // Identify the first and last block indices that can carry paragraph borders.
+        // Tables use cell shading instead of paragraph borders, so they are excluded here.
+        int firstBorderable = -1;
+        int lastBorderable = -1;
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (blocks[i] is not FencedDivTable)
+            {
+                if (firstBorderable < 0) firstBorderable = i;
+                lastBorderable = i;
+            }
+        }
+
+        // When the div starts or ends with a table, inject invisible spacer paragraphs
+        // that carry the separator borders so the zone boundary is still visible.
+        bool needTopSpacer = firstBorderable != 0 && !string.IsNullOrEmpty(style.BorderTopColor);
+        bool needBottomSpacer = lastBorderable != blocks.Count - 1 && !string.IsNullOrEmpty(style.BorderBottomColor);
+
+        if (needTopSpacer)
+            AddDivBorderSpacer(style, addTop: true, addBottom: false, isFirst: true, isLast: false);
+
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            bool addTopBorder = !needTopSpacer && i == firstBorderable;
+            bool addBottomBorder = !needBottomSpacer && i == lastBorderable;
+
+            switch (blocks[i])
+            {
+                case FencedDivParagraph p:
+                    AddDivParagraph(p.Runs, style, addTopBorder, addBottomBorder, i == 0, i == blocks.Count - 1);
+                    break;
+
+                case FencedDivHeading h:
+                    AddDivHeading(h, style, addTopBorder, addBottomBorder, i == 0, i == blocks.Count - 1);
+                    break;
+
+                case FencedDivList l:
+                    AddDivList(l, style, addTopBorder, addBottomBorder, i == 0, i == blocks.Count - 1);
+                    break;
+
+                case FencedDivTable t:
+                    AddDivTable(t.Data, style);
+                    break;
+            }
+        }
+
+        if (needBottomSpacer)
+            AddDivBorderSpacer(style, addTop: false, addBottom: true, isFirst: false, isLast: true);
+    }
+
+    /// <summary>
+    /// Renders a paragraph inside a fenced div with background shading and optional separator borders.
+    /// </summary>
+    private void AddDivParagraph(
+        IReadOnlyList<InlineRun> runs,
+        FencedDivStyle style,
+        bool addTopBorder,
+        bool addBottomBorder,
+        bool isFirst,
+        bool isLast)
+    {
+        var paragraph = _body.AppendChild(new Paragraph());
+        var props = CreateDivParagraphProperties(style, addTopBorder, addBottomBorder, isFirst, isLast);
+        paragraph.AppendChild(props);
+
+        foreach (var inlineRun in runs)
+        {
+            var run = paragraph.AppendChild(new Run());
+            var runProps = CreateBaseRunProperties(style.FontSize, style.Color, inlineRun.Bold, inlineRun.Italic);
+            if (inlineRun.IsCode)
+                ApplyInlineCodeFont(runProps, style.InlineCodeFontAscii, style.InlineCodeFontEastAsia);
+            run.AppendChild(runProps);
+            run.AppendChild(new Text(inlineRun.Text) { Space = SpaceProcessingModeValues.Preserve });
+        }
+    }
+
+    /// <summary>
+    /// Renders a heading inside a fenced div as a bold paragraph with background shading.
+    /// </summary>
+    private void AddDivHeading(
+        FencedDivHeading heading,
+        FencedDivStyle style,
+        bool addTopBorder,
+        bool addBottomBorder,
+        bool isFirst,
+        bool isLast)
+    {
+        var paragraph = _body.AppendChild(new Paragraph());
+        var props = CreateDivParagraphProperties(style, addTopBorder, addBottomBorder, isFirst, isLast);
+        paragraph.AppendChild(props);
+
+        var run = paragraph.AppendChild(new Run());
+        run.AppendChild(CreateBaseRunProperties(style.FontSize, style.Color, bold: true, italic: false));
+        run.AppendChild(new Text(heading.Text) { Space = SpaceProcessingModeValues.Preserve });
+    }
+
+    /// <summary>
+    /// Renders a list inside a fenced div with background shading on each item paragraph.
+    /// </summary>
+    private void AddDivList(
+        FencedDivList list,
+        FencedDivStyle style,
+        bool addTopBorder,
+        bool addBottomBorder,
+        bool isFirst,
+        bool isLast)
+    {
+        int itemNumber = list.StartNumber;
+        var items = list.Items.ToList();
+        for (int j = 0; j < items.Count; j++)
+        {
+            bool itemIsFirst = isFirst && j == 0;
+            bool itemIsLast = isLast && j == items.Count - 1;
+            bool itemTopBorder = addTopBorder && j == 0;
+            bool itemBottomBorder = addBottomBorder && j == items.Count - 1;
+
+            var paragraph = _body.AppendChild(new Paragraph());
+            var props = CreateDivParagraphProperties(style, itemTopBorder, itemBottomBorder, itemIsFirst, itemIsLast);
+            paragraph.AppendChild(props);
+
+            var run = paragraph.AppendChild(new Run());
+            run.AppendChild(CreateBaseRunProperties(style.FontSize, style.Color));
+
+            string bullet = list.IsOrdered ? $"{itemNumber}. " : "• ";
+            run.AppendChild(new Text(bullet + items[j].Text) { Space = SpaceProcessingModeValues.Preserve });
+
+            if (list.IsOrdered) itemNumber++;
+        }
+    }
+
+    /// <summary>
+    /// Renders a table inside a fenced div, applying background shading to all body cells.
+    /// </summary>
+    private void AddDivTable(TableData tableData, FencedDivStyle style)
+    {
+        var pageConfig = _textDirection.GetPageConfiguration();
+        int fullTextAreaTwips = (int)(uint)pageConfig.Width
+            - pageConfig.LeftMargin
+            - pageConfig.RightMargin
+            - pageConfig.GutterMargin;
+
+        // Use a default TableStyle with the div's background applied to body cells
+        var tableStyle = new CoreTableStyle
+        {
+            BodyCellBackgroundColor = string.IsNullOrEmpty(style.BackgroundColor) ? null : style.BackgroundColor
+        };
+
+        int textAreaTwips = (int)(fullTextAreaTwips * tableStyle.WidthPercent / 100.0);
+
+        var table = _body.AppendChild(new Table());
+        table.AppendChild(CreateTableProperties(tableStyle));
+        table.AppendChild(CreateTableGrid(tableData.ColumnCount, textAreaTwips));
+
+        foreach (var row in tableData.Rows)
+        {
+            table.AppendChild(CreateTableRow(row, tableData.ColumnCount, tableStyle, textAreaTwips));
+        }
+    }
+
+    /// <summary>
+    /// Creates an invisible spacer paragraph carrying a single separator border,
+    /// used when the first or last block in a fenced div is a table.
+    /// </summary>
+    private void AddDivBorderSpacer(FencedDivStyle style, bool addTop, bool addBottom, bool isFirst, bool isLast)
+    {
+        var paragraph = _body.AppendChild(new Paragraph());
+        var props = CreateDivParagraphProperties(style, addTop, addBottom, isFirst, isLast);
+        // Zero-height spacer: suppress spacing so the line appears flush with the table
+        props.AppendChild(new SpacingBetweenLines { Before = "0", After = "0" });
+        paragraph.AppendChild(props);
+    }
+
+    /// <summary>
+    /// Builds paragraph properties for a block inside a fenced div.
+    /// Applies background shading, optional separator borders, and spacing.
+    /// </summary>
+    private ParagraphProperties CreateDivParagraphProperties(
+        FencedDivStyle style,
+        bool addTopBorder,
+        bool addBottomBorder,
+        bool isFirst,
+        bool isLast)
+    {
+        var props = CreateBaseParagraphProperties();
+
+        // Separator borders (top and/or bottom separator lines delimiting the zone)
+        bool hasTopBorder = addTopBorder && !string.IsNullOrEmpty(style.BorderTopColor);
+        bool hasBottomBorder = addBottomBorder && !string.IsNullOrEmpty(style.BorderBottomColor);
+
+        if (hasTopBorder || hasBottomBorder)
+        {
+            var borders = new ParagraphBorders();
+            if (hasTopBorder)
+                borders.AppendChild(new TopBorder { Val = BorderValues.Single, Color = style.BorderTopColor, Size = style.BorderTopSize, Space = style.BorderSpace });
+            if (hasBottomBorder)
+                borders.AppendChild(new BottomBorder { Val = BorderValues.Single, Color = style.BorderBottomColor, Size = style.BorderBottomSize, Space = style.BorderSpace });
+            props.AppendChild(borders);
+        }
+
+        // Background shading
+        if (!string.IsNullOrEmpty(style.BackgroundColor))
+            props.AppendChild(CreateBackgroundShading(style.BackgroundColor));
+
+        // Line spacing
+        props.AppendChild(new SpacingBetweenLines
+        {
+            Before = isFirst ? style.SpaceBefore : "0",
+            After = isLast ? style.SpaceAfter : "0",
+            Line = style.LineSpacing,
+            LineRule = LineSpacingRuleValues.Auto
+        });
+
+        // Left indent
+        if (style.LeftIndent != "0" && !string.IsNullOrEmpty(style.LeftIndent))
+            props.AppendChild(new Indentation { Left = style.LeftIndent });
+
+        return props;
     }
 
     /// <inheritdoc/>

--- a/csharp-version/src/MarkdownToDocx.Styling/Interfaces/IStyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Interfaces/IStyleApplicator.cs
@@ -73,4 +73,12 @@ public interface IStyleApplicator
     /// <param name="coverImageOverride">CLI override for cover image path (implicitly enables title page)</param>
     /// <returns>Title page style</returns>
     TitlePageStyle ApplyTitlePageStyle(ConversionConfiguration config, string inputFilePath, string? coverImageOverride = null);
+
+    /// <summary>
+    /// Apply style configuration for a fenced div block, inheriting font settings from the base paragraph style.
+    /// </summary>
+    /// <param name="divConfig">Fenced div class configuration from YAML</param>
+    /// <param name="styles">Full style configuration (used to inherit font size, color, and line spacing)</param>
+    /// <returns>Fenced div style</returns>
+    FencedDivStyle ApplyFencedDivStyle(FencedDivClassConfig divConfig, StyleConfiguration styles);
 }

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -5,6 +5,12 @@ namespace MarkdownToDocx.Styling.Models;
 /// </summary>
 public sealed record StyleConfiguration
 {
+    // Shared empty instance used as the default value for FencedDivs so that two
+    // `new StyleConfiguration()` instances compare equal (records use reference equality
+    // for Dictionary properties; sharing the same empty instance avoids false inequality).
+    private static readonly Dictionary<string, FencedDivClassConfig> EmptyFencedDivs = new();
+
+
     /// <summary>
     /// Style configuration for H1 headings
     /// </summary>
@@ -64,6 +70,13 @@ public sealed record StyleConfiguration
     /// Style configuration for tables
     /// </summary>
     public TableStyleConfig Table { get; init; } = new();
+
+    /// <summary>
+    /// Per-class style configuration for fenced div blocks (:::classname ... :::).
+    /// Keys are class names (e.g., "try", "hint"); values define background and border styles.
+    /// Unrecognized class names are rendered without any visual treatment.
+    /// </summary>
+    public Dictionary<string, FencedDivClassConfig> FencedDivs { get; init; } = EmptyFencedDivs;
 }
 
 /// <summary>
@@ -473,4 +486,55 @@ public sealed record ImageStyleConfig
     /// Horizontal alignment of the image paragraph ("left", "center", "right")
     /// </summary>
     public string Alignment { get; init; } = "center";
+}
+
+/// <summary>
+/// Per-class style configuration for a fenced div block (:::classname ... :::).
+/// </summary>
+public sealed record FencedDivClassConfig
+{
+    /// <summary>
+    /// Background fill color in hex (e.g., "F2F2F2"). Empty = no shading.
+    /// </summary>
+    public string BackgroundColor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Top separator line color in hex (e.g., "AAAAAA"). Empty = no top border.
+    /// </summary>
+    public string BorderTopColor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Top separator line thickness in eighths of a point (default: 4 = 0.5pt).
+    /// </summary>
+    public uint BorderTopSize { get; init; } = 4;
+
+    /// <summary>
+    /// Bottom separator line color in hex (e.g., "AAAAAA"). Empty = no bottom border.
+    /// </summary>
+    public string BorderBottomColor { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Bottom separator line thickness in eighths of a point (default: 4 = 0.5pt).
+    /// </summary>
+    public uint BorderBottomSize { get; init; } = 4;
+
+    /// <summary>
+    /// Space between separator line and text in points (default: 0).
+    /// </summary>
+    public uint BorderSpace { get; init; } = 0;
+
+    /// <summary>
+    /// Spacing before the div zone in twips.
+    /// </summary>
+    public string SpaceBefore { get; init; } = "0";
+
+    /// <summary>
+    /// Spacing after the div zone in twips.
+    /// </summary>
+    public string SpaceAfter { get; init; } = "0";
+
+    /// <summary>
+    /// Left indent for div paragraphs in twips.
+    /// </summary>
+    public string LeftIndent { get; init; } = "0";
 }

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -183,6 +183,32 @@ public sealed class StyleApplicator : IStyleApplicator
         };
     }
 
+    /// <inheritdoc/>
+    public FencedDivStyle ApplyFencedDivStyle(FencedDivClassConfig divConfig, StyleConfiguration styles)
+    {
+        ArgumentNullException.ThrowIfNull(divConfig);
+        ArgumentNullException.ThrowIfNull(styles);
+
+        var para = styles.Paragraph;
+        return new FencedDivStyle
+        {
+            BackgroundColor = divConfig.BackgroundColor,
+            BorderTopColor = divConfig.BorderTopColor,
+            BorderTopSize = divConfig.BorderTopSize,
+            BorderBottomColor = divConfig.BorderBottomColor,
+            BorderBottomSize = divConfig.BorderBottomSize,
+            BorderSpace = divConfig.BorderSpace,
+            SpaceBefore = divConfig.SpaceBefore,
+            SpaceAfter = divConfig.SpaceAfter,
+            LeftIndent = divConfig.LeftIndent,
+            FontSize = para.Size * 2, // Convert pt to half-points
+            Color = para.Color,
+            LineSpacing = para.LineSpacing,
+            InlineCodeFontAscii = para.InlineCodeFontAscii,
+            InlineCodeFontEastAsia = para.InlineCodeFontEastAsia
+        };
+    }
+
     /// <summary>
     /// Resolves a potentially relative path against the directory of a base file.
     /// Absolute paths are returned unchanged.

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -2735,4 +2735,239 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         SpaceBefore = "160",
         SpaceAfter = "160"
     };
+
+    // ── FencedDiv tests ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddFencedDiv_WithParagraphOnly_ShouldApplyBackgroundAndBorders()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var content = new FencedDivContent
+        {
+            Blocks =
+            [
+                new FencedDivParagraph
+                {
+                    Runs = [new InlineRun { Text = "Try this exercise" }]
+                }
+            ]
+        };
+        var style = new FencedDivStyle
+        {
+            BackgroundColor = "F2F2F2",
+            BorderTopColor = "AAAAAA",
+            BorderTopSize = 4,
+            BorderBottomColor = "AAAAAA",
+            BorderBottomSize = 4,
+            FontSize = 22,
+            Color = "000000",
+            LineSpacing = "360"
+        };
+
+        // Act
+        builder.AddFencedDiv(content, style);
+        builder.Save();
+
+        // Assert: single paragraph with background shading, top border, and bottom border
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraphs = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .Where(p => p.ParagraphProperties?.ParagraphBorders != null)
+            .ToList();
+
+        paragraphs.Should().HaveCount(1);
+        var borders = paragraphs[0].ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<TopBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<TopBorder>()!.Color!.Value.Should().Be("AAAAAA");
+        borders.GetFirstChild<BottomBorder>()!.Val!.Value.Should().Be(BorderValues.Single);
+        borders.GetFirstChild<BottomBorder>()!.Color!.Value.Should().Be("AAAAAA");
+
+        var shading = paragraphs[0].ParagraphProperties!.GetFirstChild<Shading>();
+        shading.Should().NotBeNull();
+        shading!.Fill!.Value.Should().Be("F2F2F2");
+    }
+
+    [Fact]
+    public void AddFencedDiv_WithMultipleParagraphs_TopBorderOnFirstBottomBorderOnLast()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var content = new FencedDivContent
+        {
+            Blocks =
+            [
+                new FencedDivParagraph { Runs = [new InlineRun { Text = "First" }] },
+                new FencedDivParagraph { Runs = [new InlineRun { Text = "Middle" }] },
+                new FencedDivParagraph { Runs = [new InlineRun { Text = "Last" }] }
+            ]
+        };
+        var style = new FencedDivStyle
+        {
+            BackgroundColor = "F2F2F2",
+            BorderTopColor = "AAAAAA",
+            BorderTopSize = 4,
+            BorderBottomColor = "AAAAAA",
+            BorderBottomSize = 4,
+            FontSize = 22,
+            Color = "000000",
+            LineSpacing = "360"
+        };
+
+        // Act
+        builder.AddFencedDiv(content, style);
+        builder.Save();
+
+        // Assert: 3 paragraphs; first has top border, last has bottom border, middle has neither
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraphs = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .ToList();
+
+        paragraphs.Should().HaveCount(3);
+
+        var firstBorders = paragraphs[0].ParagraphProperties?.ParagraphBorders;
+        firstBorders.Should().NotBeNull();
+        firstBorders!.GetFirstChild<TopBorder>().Should().NotBeNull();
+        firstBorders.GetFirstChild<BottomBorder>().Should().BeNull();
+
+        var middleBorders = paragraphs[1].ParagraphProperties?.ParagraphBorders;
+        middleBorders.Should().BeNull();
+
+        var lastBorders = paragraphs[2].ParagraphProperties?.ParagraphBorders;
+        lastBorders.Should().NotBeNull();
+        lastBorders!.GetFirstChild<BottomBorder>().Should().NotBeNull();
+        lastBorders.GetFirstChild<TopBorder>().Should().BeNull();
+    }
+
+    [Fact]
+    public void AddFencedDiv_WithNoBorderColors_ShouldApplyOnlyBackground()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var content = new FencedDivContent
+        {
+            Blocks =
+            [
+                new FencedDivParagraph { Runs = [new InlineRun { Text = "Zone content" }] }
+            ]
+        };
+        var style = new FencedDivStyle
+        {
+            BackgroundColor = "EBF5FB",
+            FontSize = 22,
+            Color = "000000",
+            LineSpacing = "360"
+            // BorderTopColor and BorderBottomColor intentionally left empty
+        };
+
+        // Act
+        builder.AddFencedDiv(content, style);
+        builder.Save();
+
+        // Assert: background shading applied, no paragraph borders
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First();
+
+        paragraph.ParagraphProperties?.ParagraphBorders.Should().BeNull();
+        paragraph.ParagraphProperties?.GetFirstChild<Shading>()!.Fill!.Value.Should().Be("EBF5FB");
+    }
+
+    [Fact]
+    public void AddFencedDiv_WithTableBodyCell_ShouldApplyBackgroundShading()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var tableData = new TableData
+        {
+            ColumnCount = 2,
+            Rows =
+            [
+                new TableRowData
+                {
+                    IsHeader = true,
+                    Cells =
+                    [
+                        new TableCellData { Runs = [new InlineRun { Text = "Header 1" }] },
+                        new TableCellData { Runs = [new InlineRun { Text = "Header 2" }] }
+                    ]
+                },
+                new TableRowData
+                {
+                    IsHeader = false,
+                    Cells =
+                    [
+                        new TableCellData { Runs = [new InlineRun { Text = "Body A" }] },
+                        new TableCellData { Runs = [new InlineRun { Text = "Body B" }] }
+                    ]
+                }
+            ]
+        };
+        var content = new FencedDivContent
+        {
+            Blocks = [new FencedDivTable { Data = tableData }]
+        };
+        var style = new FencedDivStyle
+        {
+            BackgroundColor = "F2F2F2",
+            FontSize = 22,
+            Color = "000000",
+            LineSpacing = "360"
+        };
+
+        // Act
+        builder.AddFencedDiv(content, style);
+        builder.Save();
+
+        // Assert: body cells have F2F2F2 background; header cells retain default header color
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var rows = doc.MainDocumentPart!.Document.Body!
+            .Descendants<TableRow>()
+            .ToList();
+
+        rows.Should().HaveCount(2);
+
+        // Header row cells use the default header background (not div background)
+        var headerCells = rows[0].Descendants<TableCell>().ToList();
+        foreach (var cell in headerCells)
+        {
+            var shading = cell.GetFirstChild<TableCellProperties>()?.GetFirstChild<Shading>();
+            shading.Should().NotBeNull("header cell should always have shading");
+            shading!.Fill!.Value.Should().NotBe("F2F2F2", "header cell should use its own background, not the div background");
+        }
+
+        // Body row cells should have the div background applied
+        var bodyCells = rows[1].Descendants<TableCell>().ToList();
+        foreach (var cell in bodyCells)
+        {
+            var shading = cell.GetFirstChild<TableCellProperties>()?.GetFirstChild<Shading>();
+            shading.Should().NotBeNull("body cell should have div background shading");
+            shading!.Fill!.Value.Should().Be("F2F2F2");
+        }
+    }
+
+    [Fact]
+    public void AddFencedDiv_WithEmptyContent_ShouldAddNoParagraphs()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var content = new FencedDivContent { Blocks = [] };
+        var style = new FencedDivStyle { BackgroundColor = "F2F2F2", FontSize = 22, Color = "000000", LineSpacing = "360" };
+
+        // Act
+        builder.AddFencedDiv(content, style);
+        builder.Save();
+
+        // Assert: no content paragraphs added
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraphs = doc.MainDocumentPart!.Document.Body!.Descendants<Paragraph>().ToList();
+        paragraphs.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

- Implements Issue #63: fenced div blocks (`:::classname ... :::`) can now be styled natively via YAML preset configuration, eliminating the need for post-processing scripts
- Background shading is applied to all child paragraphs, headings, lists, and table body cells
- Optional top/bottom separator borders delimit the zone boundary
- 282 → 287 tests passing (5 new unit tests)

## YAML configuration example

```yaml
Styles:
  FencedDivs:
    try:
      BackgroundColor: "F2F2F2"
      BorderTopColor: "AAAAAA"
      BorderTopSize: 4
      BorderBottomColor: "AAAAAA"
      BorderBottomSize: 4
    hint:
      BackgroundColor: "EBF5FB"
```

## Markdown usage

```markdown
:::try
**Exercise heading**

| Item | Fill in |
|------|---------|
| Today's event |  |

Write above, then proceed to the next step.
:::
```

## Implementation notes

- `Markdig.UseAdvancedExtensions()` already includes `UseCustomContainers()` — no parser change needed
- `TableStyle.BodyCellBackgroundColor` (nullable) applies div background to table body cells
- When a div starts/ends with a table, invisible spacer paragraphs carry the separator borders
- Unrecognized class names render without visual treatment (graceful degradation)

## Test plan

- [x] `AddFencedDiv_WithParagraphOnly_ShouldApplyBackgroundAndBorders`
- [x] `AddFencedDiv_WithMultipleParagraphs_TopBorderOnFirstBottomBorderOnLast`
- [x] `AddFencedDiv_WithNoBorderColors_ShouldApplyOnlyBackground`
- [x] `AddFencedDiv_WithTableBodyCell_ShouldApplyBackgroundShading`
- [x] `AddFencedDiv_WithEmptyContent_ShouldAddNoParagraphs`

Closes #63