### PR TITLE
feat: add BorderStyle and IconPrefix decoration to heading styles

### DIFF
--- a/csharp-version/src/MarkdownToDocx.Core/Models/HeadingStyle.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/Models/HeadingStyle.cs
@@ -88,4 +88,23 @@ public sealed record HeadingStyle
     /// H2 directly follows H1.
     /// </summary>
     public int? SuppressPageBreakIfPrevHeadingLevel { get; init; }
+
+    /// <summary>
+    /// Border line style applied to all border positions on this heading.
+    /// Supported values: "single" (default), "double", "thick", "dotted", "dashed",
+    /// "dotDash", "wave", "triple".
+    /// </summary>
+    public string BorderStyle { get; init; } = "single";
+
+    /// <summary>
+    /// Unicode character (or short string) prepended to the heading text as a decorative prefix.
+    /// For example "◆", "★", "▶", or "01". Null or empty means no prefix.
+    /// </summary>
+    public string? IconPrefix { get; init; }
+
+    /// <summary>
+    /// Color of the icon prefix in hexadecimal format (e.g., "E91E8C").
+    /// When null, the heading's main Color is used.
+    /// </summary>
+    public string? IconPrefixColor { get; init; }
 }

--- a/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
+++ b/csharp-version/src/MarkdownToDocx.Core/OpenXml/OpenXmlDocumentBuilder.cs
@@ -130,28 +130,45 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
     }
 
     /// <summary>
+    /// Converts a border style name to the corresponding BorderValues enum value.
+    /// </summary>
+    private static BorderValues ParseBorderStyle(string borderStyle) => borderStyle.ToLowerInvariant() switch
+    {
+        "double" => BorderValues.Double,
+        "thick" => BorderValues.Thick,
+        "dotted" => BorderValues.Dotted,
+        "dashed" => BorderValues.Dashed,
+        "dotdash" => BorderValues.DotDash,
+        "wave" => BorderValues.Wave,
+        "triple" => BorderValues.Triple,
+        _ => BorderValues.Single
+    };
+
+    /// <summary>
     /// Creates a ParagraphBorders element from a comma-separated position string
     /// </summary>
     private static ParagraphBorders CreateBordersFromPositions(
         string borderPosition,
         string borderColor,
         uint borderSize,
-        uint borderSpace)
+        uint borderSpace,
+        string borderStyle = "single")
     {
         var positions = borderPosition
             .ToLowerInvariant()
             .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
+        var borderVal = ParseBorderStyle(borderStyle);
         var paragraphBorders = new ParagraphBorders();
 
         foreach (var pos in positions)
         {
             OpenXmlElement border = pos switch
             {
-                "left" => new LeftBorder { Val = BorderValues.Single, Color = borderColor, Size = borderSize, Space = borderSpace },
-                "right" => new RightBorder { Val = BorderValues.Single, Color = borderColor, Size = borderSize, Space = borderSpace },
-                "top" => new TopBorder { Val = BorderValues.Single, Color = borderColor, Size = borderSize, Space = borderSpace },
-                _ => new BottomBorder { Val = BorderValues.Single, Color = borderColor, Size = borderSize, Space = borderSpace }
+                "left" => new LeftBorder { Val = borderVal, Color = borderColor, Size = borderSize, Space = borderSpace },
+                "right" => new RightBorder { Val = borderVal, Color = borderColor, Size = borderSize, Space = borderSpace },
+                "top" => new TopBorder { Val = borderVal, Color = borderColor, Size = borderSize, Space = borderSpace },
+                _ => new BottomBorder { Val = borderVal, Color = borderColor, Size = borderSize, Space = borderSpace }
             };
             paragraphBorders.AppendChild(border);
         }
@@ -516,6 +533,15 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
         var paragraphProps = CreateHeadingParagraphProperties(level, style);
         paragraph.AppendChild(paragraphProps);
 
+        // Icon prefix run
+        if (!string.IsNullOrEmpty(style.IconPrefix))
+        {
+            var iconColor = string.IsNullOrEmpty(style.IconPrefixColor) ? style.Color : style.IconPrefixColor;
+            var iconRun = paragraph.AppendChild(new Run());
+            iconRun.AppendChild(CreateBaseRunProperties(style.FontSize, iconColor, bold: style.Bold));
+            iconRun.AppendChild(new Text(style.IconPrefix + " ") { Space = SpaceProcessingModeValues.Preserve });
+        }
+
         var run = paragraph.AppendChild(new Run());
         run.AppendChild(CreateBaseRunProperties(style.FontSize, style.Color, bold: style.Bold));
         run.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
@@ -565,7 +591,8 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
                 style.BorderPosition,
                 style.BorderColor ?? "3498db",
                 style.BorderSize,
-                style.BorderSpace));
+                style.BorderSpace,
+                style.BorderStyle));
 
             // Background shading
             if (!string.IsNullOrEmpty(style.BackgroundColor))
@@ -589,6 +616,15 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
             mainProps.AppendChild(mainSpacing);
 
             mainParagraph.AppendChild(mainProps);
+
+            // Icon prefix run
+            if (!string.IsNullOrEmpty(style.IconPrefix))
+            {
+                var iconColor = string.IsNullOrEmpty(style.IconPrefixColor) ? style.Color : style.IconPrefixColor;
+                var iconRun = mainParagraph.AppendChild(new Run());
+                iconRun.AppendChild(CreateBaseRunProperties(style.FontSize, iconColor, bold: style.Bold));
+                iconRun.AppendChild(new Text(style.IconPrefix + " ") { Space = SpaceProcessingModeValues.Preserve });
+            }
 
             var run = mainParagraph.AppendChild(new Run());
             run.AppendChild(CreateBaseRunProperties(style.FontSize, style.Color, bold: style.Bold));
@@ -635,7 +671,8 @@ public sealed class OpenXmlDocumentBuilder : IDocumentBuilder
                 style.BorderPosition,
                 style.BorderColor ?? "3498db",
                 style.BorderSize,
-                style.BorderSpace));
+                style.BorderSpace,
+                style.BorderStyle));
         }
 
         // Background shading

--- a/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Models/StyleConfiguration.cs
@@ -166,6 +166,25 @@ public sealed record HeadingStyleConfig
     /// at the specified level (e.g., set to 1 on H2 to prevent a page break after H1).
     /// </summary>
     public int? SuppressPageBreakIfPrevHeadingLevel { get; init; }
+
+    /// <summary>
+    /// Border line style for all border positions on this heading.
+    /// Supported values: "single" (default), "double", "thick", "dotted", "dashed",
+    /// "dotDash", "wave", "triple".
+    /// </summary>
+    public string BorderStyle { get; init; } = "single";
+
+    /// <summary>
+    /// Unicode character (or short string) prepended to the heading text as a decorative prefix.
+    /// For example "◆", "★", "▶", or "01". Null or empty means no prefix.
+    /// </summary>
+    public string? IconPrefix { get; init; }
+
+    /// <summary>
+    /// Color of the icon prefix in hexadecimal format (e.g., "E91E8C").
+    /// When null or empty, the heading's main Color is used.
+    /// </summary>
+    public string? IconPrefixColor { get; init; }
 }
 
 /// <summary>

--- a/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
+++ b/csharp-version/src/MarkdownToDocx.Styling/Styling/StyleApplicator.cs
@@ -47,7 +47,10 @@ public sealed class StyleApplicator : IStyleApplicator
             SpaceAfter = headingConfig.SpaceAfter,
             BorderExtent = headingConfig.BorderExtent,
             LeftIndent = headingConfig.LeftIndent,
-            SuppressPageBreakIfPrevHeadingLevel = headingConfig.SuppressPageBreakIfPrevHeadingLevel
+            SuppressPageBreakIfPrevHeadingLevel = headingConfig.SuppressPageBreakIfPrevHeadingLevel,
+            BorderStyle = headingConfig.BorderStyle,
+            IconPrefix = headingConfig.IconPrefix,
+            IconPrefixColor = headingConfig.IconPrefixColor
         };
     }
 

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/OpenXmlDocumentBuilderTests.cs
@@ -2326,6 +2326,174 @@ public class OpenXmlDocumentBuilderTests : IDisposable
         borders.GetFirstChild<RightBorder>().Should().BeNull();
     }
 
+    [Fact]
+    public void AddHeading_WithBorderStyleDouble_ShouldRenderDoubleBorder()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            ShowBorder = true,
+            BorderPosition = "bottom",
+            BorderColor = "3498db",
+            BorderSize = 12,
+            BorderSpace = 2,
+            BorderStyle = "double"
+        };
+
+        // Act
+        builder.AddHeading(1, "Double border heading", style);
+        builder.Save();
+
+        // Assert: bottom border uses Double style
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var borders = paragraph.ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<BottomBorder>()!.Val!.Value.Should().Be(BorderValues.Double);
+    }
+
+    [Fact]
+    public void AddHeading_WithBorderStyleWave_ShouldRenderWaveBorder()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            ShowBorder = true,
+            BorderPosition = "bottom",
+            BorderColor = "3498db",
+            BorderSize = 12,
+            BorderSpace = 2,
+            BorderStyle = "wave"
+        };
+
+        // Act
+        builder.AddHeading(2, "Wave border heading", style);
+        builder.Save();
+
+        // Assert: bottom border uses Wave style
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.ParagraphProperties?.ParagraphBorders != null);
+
+        var borders = paragraph.ParagraphProperties!.ParagraphBorders!;
+        borders.GetFirstChild<BottomBorder>()!.Val!.Value.Should().Be(BorderValues.Wave);
+    }
+
+    [Fact]
+    public void AddHeading_WithIconPrefix_ShouldPrependIconRun()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            IconPrefix = "◆"
+        };
+
+        // Act
+        builder.AddHeading(1, "Test Heading", style);
+        builder.Save();
+
+        // Assert: paragraph has two runs — icon prefix run and text run
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.Descendants<Run>().Any());
+
+        var runs = paragraph.Descendants<Run>().ToList();
+        runs.Should().HaveCount(2);
+        runs[0].InnerText.Should().StartWith("◆");
+        runs[1].InnerText.Should().Be("Test Heading");
+    }
+
+    [Fact]
+    public void AddHeading_WithIconPrefixColor_ShouldUseCustomColor()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            IconPrefix = "★",
+            IconPrefixColor = "E91E8C"
+        };
+
+        // Act
+        builder.AddHeading(1, "Colored Icon Heading", style);
+        builder.Save();
+
+        // Assert: icon run uses custom color, text run uses heading color
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.Descendants<Run>().Any());
+
+        var runs = paragraph.Descendants<Run>().ToList();
+        runs.Should().HaveCount(2);
+        var iconColor = runs[0].RunProperties!.GetFirstChild<Color>()!.Val!.Value;
+        var textColor = runs[1].RunProperties!.GetFirstChild<Color>()!.Val!.Value;
+        iconColor.Should().Be("E91E8C");
+        textColor.Should().Be("2c3e50");
+    }
+
+    [Fact]
+    public void AddHeading_WithIconPrefixNoColor_ShouldUseHeadingColor()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with
+        {
+            IconPrefix = "▶",
+            IconPrefixColor = null
+        };
+
+        // Act
+        builder.AddHeading(1, "Default Color Icon", style);
+        builder.Save();
+
+        // Assert: icon run uses heading color (same as text run color)
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.Descendants<Run>().Any());
+
+        var runs = paragraph.Descendants<Run>().ToList();
+        runs.Should().HaveCount(2);
+        var iconColor = runs[0].RunProperties!.GetFirstChild<Color>()!.Val!.Value;
+        var textColor = runs[1].RunProperties!.GetFirstChild<Color>()!.Val!.Value;
+        iconColor.Should().Be("2c3e50");
+        textColor.Should().Be("2c3e50");
+    }
+
+    [Fact]
+    public void AddHeading_WithNoIconPrefix_ShouldHaveSingleRun()
+    {
+        // Arrange
+        using var builder = new OpenXmlDocumentBuilder(_stream, _horizontalProvider);
+        var style = CreateDefaultHeadingStyle() with { IconPrefix = null };
+
+        // Act
+        builder.AddHeading(1, "Plain Heading", style);
+        builder.Save();
+
+        // Assert: only one run (no icon prefix)
+        _stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(_stream, false);
+        var paragraph = doc.MainDocumentPart!.Document.Body!
+            .Descendants<Paragraph>()
+            .First(p => p.Descendants<Run>().Any());
+
+        paragraph.Descendants<Run>().Should().HaveCount(1);
+    }
+
     public void Dispose()
     {
         _stream?.Dispose();

--- a/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
+++ b/csharp-version/tests/MarkdownToDocx.Tests/Unit/StyleApplicatorTests.cs
@@ -590,6 +590,74 @@ public class StyleApplicatorTests
     }
 
     [Fact]
+    public void ApplyHeadingStyle_WithBorderStyle_ShouldMapCorrectly()
+    {
+        // Arrange
+        var config = new StyleConfiguration
+        {
+            H1 = new HeadingStyleConfig
+            {
+                Size = 20,
+                Bold = true,
+                Color = "000000",
+                ShowBorder = true,
+                BorderStyle = "double"
+            }
+        };
+
+        // Act
+        var style = _applicator.ApplyHeadingStyle(1, config);
+
+        // Assert
+        style.BorderStyle.Should().Be("double");
+    }
+
+    [Fact]
+    public void ApplyHeadingStyle_WithDefaultBorderStyle_ShouldBeSingle()
+    {
+        // Act
+        var style = _applicator.ApplyHeadingStyle(1, _testConfig);
+
+        // Assert
+        style.BorderStyle.Should().Be("single");
+    }
+
+    [Fact]
+    public void ApplyHeadingStyle_WithIconPrefix_ShouldMapCorrectly()
+    {
+        // Arrange
+        var config = new StyleConfiguration
+        {
+            H2 = new HeadingStyleConfig
+            {
+                Size = 18,
+                Bold = true,
+                Color = "000000",
+                IconPrefix = "◆",
+                IconPrefixColor = "E91E8C"
+            }
+        };
+
+        // Act
+        var style = _applicator.ApplyHeadingStyle(2, config);
+
+        // Assert
+        style.IconPrefix.Should().Be("◆");
+        style.IconPrefixColor.Should().Be("E91E8C");
+    }
+
+    [Fact]
+    public void ApplyHeadingStyle_WithDefaultIconPrefix_ShouldBeNull()
+    {
+        // Act
+        var style = _applicator.ApplyHeadingStyle(1, _testConfig);
+
+        // Assert
+        style.IconPrefix.Should().BeNull();
+        style.IconPrefixColor.Should().BeNull();
+    }
+
+    [Fact]
     public void ApplyParagraphStyle_ShouldMapInlineCodeFont()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- Add `BorderStyle` property to heading styles (`single`, `double`, `thick`, `dotted`, `dashed`, `dotDash`, `wave`, `triple`)
- Add `IconPrefix` (decorative character prepended to heading text) and `IconPrefixColor` (optional custom color for the icon, falls back to heading color)
- Both single-paragraph and border-extent-text (spacer) paths updated
- 10 new unit tests added (297 total)

## YAML Usage

```yaml
H1:
  showBorder: true
  borderStyle: "double"
  borderPosition: "bottom"

H2:
  iconPrefix: "◆"
  iconPrefixColor: "E91E8C"
```

## Test plan

- [x] Build passes with no errors
- [x] 297 tests passing (10 new tests for BorderStyle and IconPrefix)
- [x] BorderStyle applies to both `AddHeadingSingleParagraph` and `AddHeadingWithSpacers`
- [x] IconPrefix prepends a separate run with correct color fallback logic
- [x] StyleApplicator correctly maps all three new properties from config to model

Closes #66